### PR TITLE
fix legend in .chromatogram for y=="bpi"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
-CHANGES IN VERSION 1.11.5
+CHANGES IN VERSION 1.11.6
 -------------------------
  o 
+
+CHANGES IN VERSION 1.11.5
+-------------------------
+ o fix BPI legend in chromatogram [2014-02-20 Thu]
 
 CHANGES IN VERSION 1.11.4
 -------------------------

--- a/R/functions-mzR.R
+++ b/R/functions-mzR.R
@@ -121,9 +121,10 @@ plotMzDelta_list <- function(object,            ## peakLists
                 tic = "Total ion current",
                 bpi = "Base peak intensity")
     yy <- switch(y,
-                tic = hd$totIonCurrent / max(hd$totIonCurrent),
-                bpi = hd$basePeakIntensity / max(hd$basePeakIntensity))
-    yy <- yy * 100
+                tic = hd$totIonCurrent,
+                bpi = hd$basePeakIntensity)
+    yymax <- max(yy)
+    yy <- yy / yymax * 100
     xx <- hd$retentionTime
     if (plot) {
         plot(yy ~ xx, type = "l", 
@@ -131,8 +132,7 @@ plotMzDelta_list <- function(object,            ## peakLists
              ...)
         abline(h = 0)
         if (legend) {
-            leg <- sprintf("%s: %.3g", toupper(y),
-                           max(hd$totIonCurrent))
+            leg <- sprintf("%s: %.3g", toupper(y), yymax)
             if (!missing(f))
                 leg <- c(f, leg)                    
             legend("topleft",


### PR DESCRIPTION
Dear Laurent,

in the legend printed by the `.chromatogram` the _TIC_ or _BPI_ is always `max(hd$totIonCurrent)`. This little patch shows the correct corresponding maximal value.

Best wishes,

Sebastian
