### PR TITLE
circumvent finalize error

### DIFF
--- a/R/readMSData.R
+++ b/R/readMSData.R
@@ -244,8 +244,11 @@ readMSData <- function(files,
   ## cache level 2 yet implemented
   cache <- testCacheArg(cache, maxCache = 2)
   if (cache >= 1) {
-    fl <- sapply(assaydata, fromFile)
-    featnms <- ls(assaydata) ## feautre names in final MSnExp
+    ## results sometimes in:
+    ##  Error in function (x)  : attempt to apply non-function
+    #fl <- sapply(assaydata, fromFile)
+    fl <- sapply(assaydata, function(x)x@fromFile)
+    featnms <- ls(assaydata) ## feature names in final MSnExp
     fl <- fl[featnms] ## reorder file numbers
     stopifnot(all(sort(featnms) == sort(fullhdorder)))
     fullhdorder <- match(featnms, fullhdorder)    


### PR DESCRIPTION
Dear Laurent,

as already mentioned in one of my last emails I always get the following error using my branch https://github.com/sgibb/MSnbase/tree/addIdentificationData :

```
s <- readMSData(c("Thermo_Hela_PRTC_1_MS2cent.mzML","Thermo_Hela_PRTC_2_MS2cent.mzML"))
Reading 13193 MS2 spectra from file Thermo_Hela_PRTC_1_MS2cent.mzML
  |=====================================================================================| 100%
Reading 13265 MS2 spectra from file Thermo_Hela_PRTC_2_MS2cent.mzML
  |=====================================================================================| 100%
Error in (function (x)  : attempt to apply non-function
Caching...
Creating 'MSnExp' object

traceback()
1: (function (x)
  x$.self$finalize())(<environment>)
```

It is very crazy because the error is thrown but R doesn't stop. The `MSnExp`
object is created correctly, e.g.:

```
validObject(s)
[1] TRUE

length(spectra(s))
[1] 26458

i <- addIdentificationData(s, c("Thermo_Hela_PRTC_1_MS2cent.mzid","Thermo_Hela_PRTC_2_MS2cent.mzid"))
dim(fData(i))
[1] 26458    26
```

The `master` branch (`MSnbase == 1.11.10`) does not show this error.

Just for documentation: a similar error was described for Reference Classes by Martin Morgan in 2011 
https://stat.ethz.ch/pipermail/r-devel/2011-December/062773.html

Via `git bisect` I tried to find the commit which introduced the error. I run `git bisect` twice and get the following commit both times: https://github.com/sgibb/MSnbase/commit/22358bdb1d471fb494f5f25f4225a5604b78fb2a
I am total confused because this commit has nothing to do with `readMSData` and in fact I did not changed/touched `readMSData.R` at all.

Using R's debug function I could identify the following line throwing the error (https://github.com/lgatto/MSnbase/blob/dea3344b76c92dbd3e3e1580d4090ce26f786e3a/R/readMSData.R#L247):

``` s
fl <- sapply(assaydata, fromFile)
```

I do not understand why this error occurs. According to https://stat.ethz.ch/pipermail/r-devel/2011-December/062773.html it has something to do with the `methods` package (and ReferenceClasses which are not involved in this line). That's why I decided to access the slot `fromFile` directly and avoid the use of the `fromFile,Spectrum-method`. And that fixes the error for me.

As I already mentioned I do not understand why the error occurs and I am not sure that my workaround is reasonable.

Could you reproduce the error using my `addIdentificationData` branch? What is your opinion about this workaround?

Best wishes,

Sebastian
