### PR TITLE
add SIp and NSAF

### DIFF
--- a/R/labelfree-functions.R
+++ b/R/labelfree-functions.R
@@ -1,13 +1,7 @@
 # SIp Spectra Index per Peptide
 # Griffin et al. 2010, PMID: 20010810
-#
 SI <- function(object, method=c("SIp", "SIgip", "SInp"), verbose=TRUE) {
-  ## remove all missing identification data
-  object <- removeNoId(object)
-
-  ## remove all identification data with multiple assignments
-  keep <- fData(object)$npsm == 1
-  object <- object[keep, ]
+  object <- .removeNoIdAndMultipleAssignments(object)
 
   method <- match.arg(method)
 
@@ -24,10 +18,46 @@ SI <- function(object, method=c("SIp", "SIgip", "SInp"), verbose=TRUE) {
   }
 
   if (method == "SInp") {
-    peplen <- fData(object)$len
-    exprs(object) <- t(t(exprs(object))/peplen)
+    ## divide by protein length
+    protlen <- fData(object)$len
+    exprs(object) <- t(t(exprs(object))/protlen)
   }
 
   return(object)
 }
 
+# (N)SAF (Normalised) Spectral Abundance Factor
+# Paoletti et al. 2006, PMID: 17138671
+SAF <- function(object, method=c("SAF", "NSAF"), verbose=TRUE) {
+  object <- .removeNoIdAndMultipleAssignments(object)
+
+  method <- match.arg(method)
+  
+  ## group by protein
+  groups <- as.factor(fData(object)$accession)
+
+  object <- combineFeatures(object, groupBy=groups, fun=length, verbose=verbose)
+
+  ## divide by protein length
+  protlen <- fData(object)$len
+  exprs(object) <- t(t(exprs(object))/protlen)
+
+  if (method == "NSAF") {
+    ## normalize by all proteins of a complex (we use all values because we
+    ## have no complex information)
+    exprs(object) <- exprs(object)/colSums(exprs(object))
+  }
+
+  return(object)
+}
+
+.removeNoIdAndMultipleAssignments <- function(object) {
+  ## remove all missing identification data
+  object <- removeNoId(object)
+
+  ## remove all identification data with multiple assignments
+  keep <- fData(object)$npsm == 1
+  object <- object[keep, ]
+  
+  return(object)
+}


### PR DESCRIPTION
Dear Laurent,

this PR adds SIp and NSAF but there is no docmentation or test cases yet.

Usage:

``` s
f <- list.files("../../playground/label_free", pattern="6000.mzML", full.names=TRUE)
id <- list.files("../../playground/label_free", pattern="6000.mzid", full.names=TRUE)

s <- readMSData(f)
si <- addIdentificationData(s, id)

mset <- MSnbase:::quantifySI_MSnExp(si)
SI(si, method="SIp")
SAF(si, method="NSAF")
```

Best wishes,

Sebastian
