### PR TITLE
add precursor normalization method for MS2 spectra

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 CHANGES IN VERSION 1.13.1
 --------------------------
- o update dependency to R >= 3.1 [2014-04-05 Sat] 
+ o Add precursor method to Spectrum2 normalisation method [2014-04-08 Tue]
 
 CHANGES IN VERSION 1.13.0
 -------------------------

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -245,11 +245,12 @@ trimMz_Spectrum <- function(x,mzlim,updatePeaksCount=TRUE) {
   return(x)
 }
 
-normalise_Spectrum <- function(object,method) {
+normalise_Spectrum <- function(object, method, value) {
   ints <- intensity(object)
   switch(method,
          max = div <- max(ints),
-         sum = div <- sum(ints))
+         sum = div <- sum(ints),
+         value = div <- value)
   normInts <- ints/div
   object@intensity <- normInts
   if (validObject(object))

--- a/R/methods-Spectrum.R
+++ b/R/methods-Spectrum.R
@@ -150,8 +150,26 @@ setReplaceMethod("centroided",
                  })
 
 setMethod("normalize", "Spectrum",
-          function(object, method=c("max","sum"),...) {
-            normalise_Spectrum(object,method=match.arg(method))
+          function(object, method = c("max", "sum"), ...) {
+            normalise_Spectrum(object, method = match.arg(method))
+        })
+
+setMethod("normalize", "Spectrum2",
+          function(object,
+                   method = c("max", "sum", "precursor"),
+                   precursorIntensity, 
+                   ...) {
+            method <- match.arg(method)
+            if (method == "precursor") {
+              precursorIntensity <- ifelse(missing(precursorIntensity), 
+                                           object@precursorIntensity,
+                                           precursorIntensity)
+              return(normalise_Spectrum(object, 
+                                        method = "value", 
+                                        value = precursorIntensity))
+            } else {
+              return(callNextMethod(object, method, ...))
+            }
         })
 
 normalise <- normalize

--- a/man/normalise-methods.Rd
+++ b/man/normalise-methods.Rd
@@ -2,10 +2,12 @@
 \docType{methods}
 \alias{normalise-methods}
 \alias{normalise,Spectrum-method}
+\alias{normalise,Spectrum2-method}
 \alias{normalise,MSnSet-method}
 \alias{normalise,MSnExp-method}
 \alias{normalize-methods}
 \alias{normalize,Spectrum-method}
+\alias{normalize,Spectrum2-method}
 \alias{normalize,MSnSet-method}
 \alias{normalize,MSnExp-method}
 \alias{scale,MSnSet-method}
@@ -19,13 +21,16 @@
 \description{
   The \code{normalise} method (also available as \code{normalize})
   performs basic normalisation on spectra 
-  intensities of single spectra (\code{"\linkS4class{Spectrum}"}
-  objects), whole experiments (\code{"\linkS4class{MSnExp}"} objects) or
+  intensities of single spectra (\code{"\linkS4class{Spectrum}"} or 
+  \code{"\linkS4class{Spectrum2}"} objects),
+  whole experiments (\code{"\linkS4class{MSnExp}"} objects) or
   quantified expression data (\code{"\linkS4class{MSnSet}"} objects).
 
   Raw spectra and experiments are normalised using \code{max} or
-  \code{sum} only. Each peak intensity is divided by the highest
-  intensity in the spectrum or the sum of intensities.
+  \code{sum} only. For MSMS spectra could be normalised to their 
+  \code{precursor} additionally. Each peak intensity is divided by the
+  highest intensity in the spectrum, the sum of intensities or the intensity 
+  of the precursor.
   These methods aim at facilitating relative peaks heights between
   different spectra.
 
@@ -53,7 +58,8 @@
 
 \arguments{
   \item{object}{ An object of class \code{"\linkS4class{Spectrum}"}, 
-    \code{"\linkS4class{MSnExp}"} or \code{"\linkS4class{MSnSet}"}.
+    \code{"\linkS4class{Spectrum2}"}, \code{"\linkS4class{MSnExp}"} or
+    \code{"\linkS4class{MSnSet}"}.
   }
   \item{method}{
     A character vector of length one that describes how to normalise
@@ -75,6 +81,12 @@
     \item{\code{signature(object = "Spectrum", method = "character")}}{
       Normalises the \code{object} peak intensities using
       \code{method}. }
+    \item{\code{signature(object = "Spectrum2", method = "character",
+        precursorIntensity)}}{
+      Normalises the \code{object} peak intensities using
+      \code{method}. If \code{method == "precursor"}, 
+      \code{precursorIntensity} allows to specify the intensity of the
+      precursor manually. }
   }
   The \code{scale} method:
   \describe{

--- a/tests/testthat/test_Spectrum.R
+++ b/tests/testthat/test_Spectrum.R
@@ -36,6 +36,28 @@ test_that("Spectrum processing", {
   expect_that(ionCount(sp4),equals(sum(int[10:20])))  
 })
 
+test_that("Spectrum processing", {
+  s1 <- new("Spectrum1", mz=1:5, intensity=1:5)
+  s2 <- new("Spectrum2", mz=1:5, intensity=1:5, precursorIntensity=10)
+
+  ## Spectrum1
+  ## max is default
+  expect_equal(intensity(normalize(s1)), (1:5)/5)
+  expect_equal(intensity(normalise(s1)), (1:5)/5)
+  expect_equal(intensity(normalize(s1, method="max")), (1:5)/5)
+  expect_equal(intensity(normalize(s1, method="sum")), (1:5)/15)
+  expect_error(normalize(s1, method="precursor"), "'arg' should be one of")
+
+  ## Spectrum2
+  ## max is default
+  expect_equal(intensity(normalize(s2)), (1:5)/5)
+  expect_equal(intensity(normalise(s2)), (1:5)/5)
+  expect_equal(intensity(normalize(s2, method="max")), (1:5)/5)
+  expect_equal(intensity(normalize(s2, method="sum")), (1:5)/15)
+  expect_equal(intensity(normalize(s2, method="precursor")), (1:5)/10)
+  expect_equal(intensity(normalize(s2, method="precursor", 
+                         precursorIntensity=20)), (1:5)/20)
+})
 
 test_that("Spectrum quantification", {
   ## dummy Spectrum


### PR DESCRIPTION
Dear Laurent,

this PR adds a `"precursor"` normalization method for the `Spectrum2` class:

``` s
s2 <- new("Spectrum2", mz=1:5, intensity=1:5, precursorIntensity=10)
intensity(normalize(s2, method="precursor"))
# [1] 0.1 0.2 0.3 0.4 0.5
intensity(normalize(s2, method="precursor", precursorIntensity=20))
# [1] 0.05 0.10 0.15 0.20 0.25
```

Additionally I add some test cases for normalization of spectra in general.

Best wishes,

Sebastian
