### PR TITLE
partly rewrite readMgfData

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 CHANGES IN VERSION 1.15.4
 -------------------------
+ o partly rewrite readMgfData [2015-01-19 Mon]
  o
  
 CHANGES IN VERSION 1.15.3

--- a/man/readMgfData.Rd
+++ b/man/readMgfData.Rd
@@ -6,8 +6,8 @@
 }
 
 \description{
-  Reads an mgf file and generates an \code{"\linkS4class{MSnExp}"}
-  object. 
+  Reads a mgf file and generates an \code{"\linkS4class{MSnExp}"}
+  object.
 }
 
 \usage{


### PR DESCRIPTION
While thinking about #42 I stumble on the `readMgfData` function. I partly rewrote it to simplify it (IMHO) and to decrease the running time (a little bit):

The original version:
```r
packageVersion("MSnbase"); system.time(itraqdata2 <- readMgfData("itraqdata.mgf", verbose=FALSE))
# [1] ‘1.15.2’
#   user  system elapsed 
#  2.824   0.008   2.841
> packageVersion("MSnbase"); system.time(itraqdata2 <- readMgfData("3_2.mgf", verbose=FALSE))
# [1] ‘1.15.2’
#   user  system elapsed 
#281.958   0.132 282.990
```
The new one:
```r
packageVersion("MSnbase"); system.time(itraqdata2 <- readMgfData("itraqdata.mgf", verbose=FALSE))
# [1] ‘1.15.4’
#   user  system elapsed 
#  2.072   0.004   2.082
> packageVersion("MSnbase"); system.time(itraqdata2 <- readMgfData("3_2.mgf", verbose=FALSE))
# [1] ‘1.15.4’
#   user  system elapsed 
#221.946   0.152 222.766
```
As far as I can see and test the results are identical.
