### PR TITLE
mzR as backend for addIdentificationData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Author: Laurent Gatto <lg390@cam.ac.uk> with contributions from
 	Vladislav Petyuk, Thomas Naake and Sebastian Gibb.
 Maintainer: Laurent Gatto <lg390@cam.ac.uk>
 Depends: R (>= 3.1), methods, BiocGenerics (>= 0.7.1),
-	 Biobase (>= 2.15.2), mzR, BiocParallel
+	 Biobase (>= 2.15.2), mzR (>= 2.1.6), BiocParallel
 Imports: plyr, IRanges, preprocessCore, vsn, grid,
 	 reshape2, stats4, affy, impute, pcaMethods,
 	 MALDIquant (>= 1.9.8), digest, lattice, ggplot2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,10 +32,9 @@ Depends: R (>= 3.1), methods, BiocGenerics (>= 0.7.1),
 	 Biobase (>= 2.15.2), mzR, BiocParallel
 Imports: plyr, IRanges, preprocessCore, vsn, grid,
 	 reshape2, stats4, affy, impute, pcaMethods,
-	 mzID (>= 1.5.2), MALDIquant (>= 1.9.8), digest,
-	 lattice, ggplot2
+	 MALDIquant (>= 1.9.8), digest, lattice, ggplot2
 Suggests: testthat, zoo, knitr (>= 1.1.0), rols, Rdisop, pRoloc,
-	  pRolocdata (>= 1.0.7), msdata, roxygen2, rgl, BiocStyle
+	  pRolocdata (>= 1.0.7), msdata, roxygen2, rgl, BiocStyle, mzID (>= 1.5.2)
 License: Artistic-2.0
 LazyData: yes
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -22,8 +22,6 @@ importFrom(vsn, vsn2, meanSdPlot)
 importFrom(IRanges, IRanges)
 importClassesFrom(IRanges, IRanges)
 importFrom(affy, MAplot, ma.plot, mva.pairs)
-importFrom(mzID, mzID, flatten)
-importClassesFrom(mzID, mzID)
 importFrom(digest, digest)
 
 export(MSnSet,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -23,7 +23,7 @@ importFrom(IRanges, IRanges)
 importClassesFrom(IRanges, IRanges)
 importFrom(affy, MAplot, ma.plot, mva.pairs)
 importFrom(mzID, mzID, flatten)
-importClassesFrom(mzID, mzID, mzIDCollection)
+importClassesFrom(mzID, mzID)
 importFrom(digest, digest)
 
 export(MSnSet,

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 CHANGES IN VERSION 1.15.5
 -------------------------
+ o add mzR support for addIdentificationData [2015-02-01 Sun]
+ o move mzID to Suggests [2015-02-01 Sun]
  o update dependency to mzID >= 1.5.2 [2015-01-28 Wed]
  o rewrite addIdentificationData and change its signature [2015-01-28 Wed]
  o add methods addIdentificationData which work on MSnExp and MSnSets using

--- a/R/AllClassUnions.R
+++ b/R/AllClassUnions.R
@@ -1,1 +1,0 @@
-setClassUnion("mzIDClasses", c("mzID", "mzIDCollection"))

--- a/R/methods-MSnExp.R
+++ b/R/methods-MSnExp.R
@@ -287,16 +287,27 @@ setMethod("addIdentificationData", c("MSnExp", "character"),
           function(object, id,
                    fcol = c("spectrum.file", "acquisition.number"),
                    icol = c("spectrumFile", "acquisitionnum"),
+                   backend = c("mzR", "mzID"),
                    verbose = TRUE) {
-            addIdentificationData(object, id = mzID(id, verbose = verbose),
-                                  fcol = fcol, icol = icol)
+            utils.addIdentificationData(object, filenames = id,
+                                        fcol = fcol, icol = icol,
+                                        backend = backend,
+                                        verbose = verbose)
           })
 
-setMethod("addIdentificationData", c("MSnExp", "mzIDClasses"),
+setMethod("addIdentificationData", c("MSnExp", "mzID"),
           function(object, id,
                    fcol = c("spectrum.file", "acquisition.number"),
                    icol = c("spectrumFile", "acquisitionnum"), ...) {
             addIdentificationData(object, id = flatten(id),
+                                  fcol = fcol, icol = icol)
+          })
+
+setMethod("addIdentificationData", c("MSnExp", "mzRident"),
+          function(object, id,
+                   fcol = c("spectrum.file", "acquisition.number"),
+                   icol = c("spectrumFile", "acquisitionnum"), ...) {
+            addIdentificationData(object, id = utils.mzRident2df(id),
                                   fcol = fcol, icol = icol)
           })
 

--- a/R/methods-MSnSet.R
+++ b/R/methods-MSnSet.R
@@ -609,16 +609,27 @@ setMethod("addIdentificationData", c("MSnSet", "character"),
           function(object, id,
                    fcol = c("spectrum.file", "acquisition.number"),
                    icol = c("spectrumFile", "acquisitionnum"),
+                   backend = c("mzR", "mzID"),
                    verbose = TRUE) {
-            addIdentificationData(object, id = mzID(id, verbose = verbose),
-                                  fcol = fcol, icol = icol)
+            utils.addIdentificationData(object, filenames = id,
+                                        fcol = fcol, icol = icol,
+                                        backend = backend,
+                                        verbose = verbose)
           })
 
-setMethod("addIdentificationData", c("MSnSet", "mzIDClasses"),
+setMethod("addIdentificationData", c("MSnSet", "mzID"),
           function(object, id,
                    fcol = c("spectrum.file", "acquisition.number"),
                    icol = c("spectrumFile", "acquisitionnum"), ...) {
             addIdentificationData(object, id = flatten(id),
+                                  fcol = fcol, icol = icol)
+          })
+
+setMethod("addIdentificationData", c("MSnSet", "mzRident"),
+          function(object, id,
+                   fcol = c("spectrum.file", "acquisition.number"),
+                   icol = c("spectrumFile", "acquisitionnum"), ...) {
+            addIdentificationData(object, id = utils.mzRident2df(id),
                                   fcol = fcol, icol = icol)
           })
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -721,20 +721,20 @@ utils.mzRident2df <- function(object) {
   psms <- psms(object)
   psms$spectrumFile <- basename(sourceInfo(object))
   psms$idFile <- basename(fileName(object))
-  ## TODO: hopefully this would be part of mzR
-  ## see https://github.com/sneumann/mzR/issues/17
-  psms$acquisitionnum <- as.numeric(sub("^.*=([[:digit:]]+)$", "\\1", psms$spectrumID))
 
   ## rename mzR columns into mzID compatible columns
-  pattern <- c("DatabaseAccess", "DatabaseDescription", "sequence")
-  replacement <- c("accession", "description", "pepseq")
-  colnames(psms)[match(pattern, colnames(psms))] <- replacement
+  pattern <- c("acquisitionNum", "DatabaseAccess", "DatabaseDescription",
+               "sequence", "DBseqLength")
+  replacement <- c("acquisitionnum", "accession", "description",
+                   "pepseq", "length")
+  i <- match(pattern, colnames(psms))
+  colnames(psms)[i[!is.na(i)]] <- replacement[!is.na(i)]
 
   ## convert all factors into characters
   i <- sapply(psms, is.factor)
   psms[i] <- lapply(psms[i], as.character)
 
-  return(psms)
+  return(cbind(psms, score(object)))
 }
 
 utils.addIdentificationData <- function(object, filenames,

--- a/man/MSnExp-class.Rd
+++ b/man/MSnExp-class.Rd
@@ -23,9 +23,8 @@
 \alias{removeReporters,MSnExp-method}
 \alias{smooth,MSnExp-method}
 \alias{addIdentificationData,MSnExp,character-method}
-\alias{addIdentificationData,MSnExp,mzIDClasses-method}
 \alias{addIdentificationData,MSnExp,mzID-method}
-\alias{addIdentificationData,MSnExp,mzIDCollection-method}
+\alias{addIdentificationData,MSnExp,mzRident-method}
 \alias{addIdentificationData,MSnExp,data.frame-method}
 \alias{removeNoId,MSnExp-method}
 \alias{removeMultipleAssignment,MSnExp-method}

--- a/man/MSnSet-class.Rd
+++ b/man/MSnSet-class.Rd
@@ -42,9 +42,8 @@
 \alias{image,MSnSet-method}
 \alias{MAplot,MSnSet-method}
 \alias{addIdentificationData,MSnSet,character-method}
-\alias{addIdentificationData,MSnSet,mzIDClasses-method}
 \alias{addIdentificationData,MSnSet,mzID-method}
-\alias{addIdentificationData,MSnSet,mzIDCollection-method}
+\alias{addIdentificationData,MSnSet,mzRident-method}
 \alias{addIdentificationData,MSnSet,data.frame-method}
 \alias{removeNoId,MSnSet-method}
 \alias{removeMultipleAssignment-method}

--- a/man/addIdentificationData-methods.Rd
+++ b/man/addIdentificationData-methods.Rd
@@ -14,16 +14,22 @@
   \describe{
 
     \item{\code{signature(object = "MSnExp", id = "character",
-        fcol = "character", icol = "character", verbose = "logical")}}{
+        fcol = "character", icol = "character",
+        backend = "character", verbose = "logical")}}{
       Adds the identification data stored in mzIdentML files to a
       \code{"\linkS4class{MSnExp}"} instance. The method handles
       one or multiple mzIdentML files provided via \code{id}. \code{id} has to
       be a \code{character} vector of valid filenames.
+
       \code{fcol} and \code{icol} specify the columns in the \code{featureData}
       slot and the identification \code{data.frame} that are used to merge both
       data together as \code{character} vectors
       (defaults are \code{fcol = c("spectrum.file", "acquisition.number")} and
       \code{icol = c("spectrumFile", "acquisitionnum")}).
+
+      The default \code{backend} is \code{"mzR"}. Set it to \code{"mzID"} to use
+      the \emph{mzID} package for parsing the mzIdentML files.
+
       The \code{verbose} argument (default is
       \code{TRUE}) defines whether status messages should be showed.
     }
@@ -33,18 +39,13 @@
       Same as above but \code{id} could be an \code{mzID} object.
     }
 
-    \item{\code{signature(object = "MSnExp", id = "mzIDCollection",
-        fcol = "character", icol = "character", verbose = "logical")}}{
-      Same as above but \code{id} could be an \code{mzIDCollection} object.
-    }
-
     \item{\code{signature(object = "MSnExp", id = "data.frame",
         fcol = "character", icol = "character", verbose = "logical")}}{
       Same as above but \code{id} could be a \code{data.frame}.
     }
 
     \item{\code{signature(object = "MSnSet", id = "character",
-	    verbose = "logical")}}{
+        backend = "character", verbose = "logical")}}{
       Adds the identification data stored in mzIdentML files to an
       \code{"\linkS4class{MSnSet}"} instance.
       The method handles one or multiple mzIdentML files provided via
@@ -57,6 +58,9 @@
       (defaults are \code{fcol = c("spectrum.file", "acquisition.number")} and
       \code{icol = c("spectrumFile", "acquisitionnum")}).
 
+      The default \code{backend} is \code{"mzR"}. Set it to \code{"mzID"} to use
+      the \emph{mzID} package for parsing the mzIdentML files.
+
       The \code{verbose} argument (default is
       \code{TRUE}) defines whether status messages should be showed.
     }
@@ -64,11 +68,6 @@
     \item{\code{signature(object = "MSnSet", id = "mzID",
         fcol = "character", icol = "character", verbose = "logical")}}{
       Same as above but \code{id} could be an \code{mzID} object.
-    }
-
-    \item{\code{signature(object = "MSnSet", id = "mzIDCollection",
-        fcol = "character", icol = "character", verbose = "logical")}}{
-      Same as above but \code{id} could be an \code{mzIDCollection} object.
     }
 
     \item{\code{signature(object = "MSnSet", id = "data.frame",

--- a/man/removeNoId-methods.Rd
+++ b/man/removeNoId-methods.Rd
@@ -49,7 +49,7 @@
   fData(msexp2)$pepseq
 
   ## using keep
-  (k <- fData(msexp)$'ms-gf:evalue' > 75)
+  (k <- fData(msexp)$'MS_GF_EValue' > 75)
   k[is.na(k)] <- FALSE
   k
   msexp3 <- removeNoId(msexp, keep = k)

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -196,8 +196,7 @@ test_that("addIdentificationData", {
   aa <- readMSData(quantFile, verbose = FALSE)
 
   expect_error(addIdentificationData(aa, "foobar.mzid",
-                                     verbose = FALSE),
-               "does not exist")
+                                     verbose = FALSE))
 
   fd <- fData(addIdentificationData(aa, identFile, verbose = FALSE))
 


### PR DESCRIPTION
Dear Laurent,

this PR introduces `mzR` as backend for `addIdentificationData`.

Sadly it is far from perfect. While I could circumvent most problems by renaming the columns of the `mzR::psms` output similar to the output of `flatten(mzID(...))` the label-free quantification fails because `mzR::psms` has no `length` column. Is there a way to calculate this column? Otherwise we need to open an issue against `mzR`.

```r
quantFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                 full.name = TRUE, pattern = "mzXML$")
identFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                 full.name = TRUE, pattern = "dummyiTRAQ.mzid")

msexp <- readMSData(quantFile)

msexpMzID <- addIdentificationData(msexp, identFile, backend="mzID")
msexpMzR <- addIdentificationData(msexp, identFile, backend="mzR")

quantify(msexpMzID, "SIn")
quantify(msexpMzR, "SIn")
# Error in SI(object, method, ...) :
#  lengthnot found in fvarLabel(.). 'plength' must a feature variable
```