### PR TITLE
MALDIquant 1.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,11 +28,11 @@ Author: Laurent Gatto <lg390@cam.ac.uk> with contributions from
 	Guangchuang Yu, Samuel Wieczorek, Vasile-Cosmin Lazar,
 	Vladislav Petyuk, Thomas Naake and Sebastian Gibb.
 Maintainer: Laurent Gatto <lg390@cam.ac.uk>
-Depends: R (>= 3.1), methods, BiocGenerics (>= 0.7.1), 
-	 Biobase (>= 2.15.2), mzR, BiocParallel, ProtGenerics	 
+Depends: R (>= 3.1), methods, BiocGenerics (>= 0.7.1),
+	 Biobase (>= 2.15.2), mzR, BiocParallel, ProtGenerics
 Imports: plyr, IRanges, preprocessCore, vsn, grid,
 	 reshape2, stats4, affy, impute, pcaMethods,
-	 mzID (>= 1.5.2), MALDIquant (>= 1.9.8), digest,
+	 mzID (>= 1.5.2), MALDIquant (>= 1.12), digest,
 	 lattice, ggplot2, S4Vectors, Rcpp
 Suggests: testthat, zoo, knitr (>= 1.1.0), rols, Rdisop, pRoloc,
 	  pRolocdata (>= 1.7.1), msdata, roxygen2, rgl, BiocStyle,

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -351,7 +351,7 @@ pickPeaks_Spectrum <- function(object, halfWindowSize = 2L,
                                              halfWindowSize = halfWindowSize)
 
   ## include only local maxima which are above the noise
-  isAboveNoise <- object@intensity > (SNR * noise[, 2L])
+  isAboveNoise <- object@intensity > (SNR * noise)
 
   peakIdx <- which(isAboveNoise & isLocalMaxima)
 


### PR DESCRIPTION
Dear Laurent,

the upcoming MALDIquant release will have some changes to internal functions. Currently the only one that affects MSnbase is `.estimateNoise` that returns a simple numeric vector instead of a matrix.

This PR is a reminder. I will merge it myself when MALDIquant 1.12 is released on CRAN (I will need some more days to test etc.). But it would be necessary to cherry-pick this PR into the stable/release branch on bioc as well.

Best wishes,

Sebastian