### PR TITLE
Added description in iPQF header

### DIFF
--- a/R/iPQF.R
+++ b/R/iPQF.R
@@ -188,10 +188,13 @@ uni.measured.dist <- function(pos, uniques.all, mat) {
 
 
 ##' The iPQF spectra-to-protein summarisation method integrates
-##' peptide characteristics and quantitative values for protein
-##' quantitation estimation, were peptide spectra receive weights and
-##' contribute to the protein quantification according to their
-##' reliability. See also \code{\link{combineFeatures}} for a more
+##' peptide spectra characteristics and quantitative values for protein
+##' quantitation estimation. Spectra features, such as charge state, 
+##' sequence length, identification score and others, contain valuable 
+##' information concerning quantification accuracy. The iPQF algorithm 
+##' assigns weights to spectra according to their overall feature reliability
+##' and computes a weighted mean to estimate protein quantities.
+##' See also \code{\link{combineFeatures}} for a more
 ##' general overview of feature aggregation and examples.
 ##'
 ##' @title iPQF: iTRAQ (and TMT) Protein Quantification based on Features
@@ -201,7 +204,7 @@ uni.measured.dist <- function(pos, uniques.all, mat) {
 ##' matching. Generally, this is a feature variable such as
 ##' \code{fData(object)$accession}.
 ##' @param low.support.filter A \code{logical} specifying if proteins
-##' being supported by only 1-2 peptides should be filtered
+##' being supported by only 1-2 peptide spectra should be filtered
 ##' out. Default is \code{FALSE}.
 ##' @param ratio.calc Either \code{"none"} (don't calculate any
 ##' ratios), \code{"sum"} (default), or a specific channel (one of
@@ -210,7 +213,7 @@ uni.measured.dist <- function(pos, uniques.all, mat) {
 ##' @param method.combine A \code{logical} defining whether to further
 ##' use median polish to combine features.
 ##' @return A \code{matrix} with estimated protein ratios.
-##' @author Martina Fisher
+##' @author Martina Fischer
 iPQF <- function(object, groupBy,
                  low.support.filter = FALSE,
                  ratio.calc = "sum",


### PR DESCRIPTION
I edited the description in the iPQF.R from the iPQF branch. I just realised that this iPQF.R version I forked from your repository was missing 'the examples and reference' on the iPQF branch, these are only found in the iPQF.R on the master. This confused me a bit and I stayed with the branch.

So far, I only edited the description, but maybe adding some more information about the features used in the details section might be helpful after their naming is solved? Also I could add sth why a combination with MedianPolish might be useful.
