### PR TITLE
partly rewrite writeMgfData

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 CHANGES IN VERSION 1.17.12
 --------------------------
- o
- 
+ o partly rewrite writeMgfData [2015-05-16 Thu]
+
 CHANGES IN VERSION 1.17.11
 --------------------------
  o adding unit tests <2015-07-01 Wed>
@@ -9,7 +9,7 @@ CHANGES IN VERSION 1.17.11
    <2015-07-01 Wed>
  o new mzTabMode and mzTabType shortcut accessors for mode and type of
    an mzTab data <2015-07-01 Wed>
- 
+
 CHANGES IN VERSION 1.17.10
 --------------------------
  o Fix URL <2015-06-30 Tue>

--- a/R/readWriteMgfData.R
+++ b/R/readWriteMgfData.R
@@ -56,7 +56,7 @@ writeMgfContent <- function(sp, TITLE = NULL, con) {
     cat(..., file=file, sep=sep, append=append)
   }
 
-  .cat("BEGIN IONS\n",
+  .cat("\nBEGIN IONS\n",
        "SCANS=", acquisitionNum(sp))
 
   if (is.null(TITLE)) {
@@ -83,7 +83,7 @@ writeMgfContent <- function(sp, TITLE = NULL, con) {
   }
 
   .cat("\n", paste(mz(sp), intensity(sp), collapse = "\n"))
-  .cat("\nEND IONS\n\n")
+  .cat("\nEND IONS\n")
 }
 
 # Based on the code contributed by Guangchuang Yu <guangchuangyu@gmail.com>


### PR DESCRIPTION
This PR partly rewrites `writeMgfData`. That solves the error in https://github.com/lgatto/synapter/issues/89 and results in a nearly 2x times faster export.