### PR TITLE
use lapply in subsetBy

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -322,27 +322,25 @@ getTopIdx <- function(X, n, fun, ...) {
 }
 
 subsetBy <- function(X, groups, byIdx) {
-  ans <- c()
   if ( is.null(dim(X)) || ncol(X) == 1 ) {
+    ## vector like
     X <- as.vector(X)
-    for (l_i in unique(groups)) {
+    ans <- unlist(lapply(unique(groups), function(l_i) {
       X_i <- X[groups == l_i]
       j <- byIdx[[l_i]]
-      ans <- c(ans, X_i[j])
-    }
+      X_i[j]
+    }))
   } else {
-    for (l_i in unique(groups)) {
-      X_i <- X[groups == l_i, ]
+    ## matrix like
+    ans <- lapply(unique(groups), function(l_i) {
+      X_i <- X[groups == l_i, , drop=FALSE]
       j <- byIdx[[l_i]]
-      ifelse(is.vector(X_i),
-             ans <- base::rbind(ans, X_i),
-             ans <- base::rbind(ans, X_i[j, ]))
-    }
+      X_i[j, , drop=FALSE]
+    })
+    ans <- do.call(rbind, ans)
   }
-  return(ans)
+  ans
 }
-
-
 
 ## Computes header from assay data by-passing cache
 .header <- function(object) {


### PR DESCRIPTION
Dear Laurent,

this PR replace the `for` loop in `subsetBy` (that contains a growing vector) with a `lapply` based solution.
This results in a slightly faster subsetting:
```r
library("git2r")
library("devtools")

repo <- repository("MSnbase")

checkout(repo, branch="master")
load_all("MSnbase")
load_all("synapter")

load(file.path(system.file("data", package="synapterdata"), "ups25a.rda"))
ms25a <- as(ups25a, "MSnSet")

system.time({ma <- topN(ms25a, groupBy = fData(ms25a)$protein.Accession, n = 3) })
#   user  system elapsed
#  2.064   0.000   2.066

checkout(repo, branch="lapply")
load_all("MSnbase")
system.time({la <- topN(ms25a, groupBy = fData(ms25a)$protein.Accession, n = 3) })
#    user  system elapsed
#   1.200   0.008   1.207

checkout(repo, branch="split")
load_all("MSnbase")
system.time({sp <- topN(ms25a, groupBy = fData(ms25a)$protein.Accession, n = 3) })
#    user  system elapsed
#   0.692   0.004   0.695
```
This approach doesn't change anything (all topN tests pass) and has (hopefully) no negative side effects. 

As you could see there is another branch *split* https://github.com/lgatto/MSnbase/blob/split/R/utils.R#L324-L338 that uses a `split` approach that is even faster.
The `split` approach returns its results in a different order (order of the levels of `group`) in contrast to the original one and to the `lapply` approach (order of appearance in `group`). That's why some unit tests fail and why I don't offer the `split` solution as PR. I think I will need your help to ensure everything is correct in the split branch.