### PR TITLE
featureCV ignores its na.rm argument

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -163,7 +163,7 @@ makeImpuritiesMatrix <- function(x, filename, edit = TRUE) {
         ## test <- test/100
         M <- res/100
         rownames(M) <- colnames(M) <-
-            paste("reporter", 1:x, sep=".")        
+            paste("reporter", 1:x, sep=".")
     } else {
         if (x==4) {
             M <- matrix(c(0.929,0.059,0.002,0.000,
@@ -197,7 +197,7 @@ makeImpuritiesMatrix <- function(x, filename, edit = TRUE) {
                              0.9678, 0, 0.013, 0, 0.001, 0, 0, 0, 0.003, 0.047, 0, 0.9678, 0,
                              0.012, 0, 0, 0, 0, 0, 0.002, 0.0259, 0, 0.962, 0, 0.029, 0, 0, 0, 0,
                              0, 0, 0.0249, 0, 0.933, 0, 0.0236, 0, 0, 0, 0, 0, 0, 0.025, 0, 0.941,
-                             0, 0, 0, 0, 0, 0, 0, 0, 0.028, 0, 0.9621),                      
+                             0, 0, 0, 0, 0, 0, 0, 0, 0.028, 0, 0.9621),
                            .Dim = c(10L, 10L),
                            .Dimnames = list(
                                c("126", "127N", "127C", "128N", "128C",
@@ -859,4 +859,24 @@ compareMSnSets <- function(x, y, qual = FALSE, proc = FALSE) {
     if (!qual)  ## do not compare @qual
         x@qual <- y@qual
     all.equal(x, y)
+}
+
+##' Similar to colMeans but calculates the sd. Should be identical to
+##' apply(x, 2, sd, na.rm).
+##' based on: http://stackoverflow.com/questions/17549762/is-there-such-colsd-in-r/17551600#17551600
+##' @title colSd
+##' @param x matrix/data.frame
+##' @param na.rm logical. Should missing values (including ‘NaN’) be omitted
+##' from the calculations?
+##' @return double
+##' @author Sebastian Gibb
+##' @noRd
+utils.colSd <- function(x, na.rm = TRUE) {
+  if (na.rm) {
+    n <- colSums(!is.na(x))
+  } else {
+    n <- nrow(x)
+  }
+  colVar <- colMeans(x*x, na.rm = na.rm) - (colMeans(x, na.rm = na.rm))^2L
+  sqrt(colVar * n/(n - 1L))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -869,7 +869,7 @@ compareMSnSets <- function(x, y, qual = FALSE, proc = FALSE) {
 ##' @param na.rm logical. Should missing values (including ‘NaN’) be omitted
 ##' from the calculations?
 ##' @return double
-##' @author Sebastian Gibb
+##' @author Sebastian Gibb <mail@@sebastiangibb.de>
 ##' @noRd
 utils.colSd <- function(x, na.rm = TRUE) {
   if (na.rm) {

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -148,3 +148,13 @@ test_that("formatRt", {
     expect_equal(tc, formatRt(tn))
     expect_equal(tn, formatRt(tc))
 })
+
+test_that("colSd", {
+  set.seed(1)
+  m <- matrix(rnorm(10), ncol=2)
+  mna <- m
+  mna[c(1, 8)] <- NA
+  expect_equal(MSnbase:::utils.colSd(m), apply(m, 2, sd))
+  expect_equal(MSnbase:::utils.colSd(m, na.rm=TRUE),
+               apply(m, 2, sd, na.rm=TRUE))
+})


### PR DESCRIPTION
While creating the `MSnSet`s for the synapter objects I recognized `NA`s in the `CV` column. The `NA`s even survive `na.rm=TRUE`:

MWE:
```r
library("MSnbase")
data(msnset)
msnset <- msnset[41:43]
featureCV(msnset, factor(rep(1, nrow(msnset))), na.rm=FALSE)
#   CV.iTRAQ4.114 CV.iTRAQ4.115 CV.iTRAQ4.116 CV.iTRAQ4.117
# 1     0.4695498     0.2907382            NA     0.5489767
featureCV(msnset, factor(rep(1, nrow(msnset))), na.rm=TRUE)
#   CV.iTRAQ4.114 CV.iTRAQ4.115 CV.iTRAQ4.116 CV.iTRAQ4.117
# 1     0.4695498     0.2907382            NA     0.5489767
```

expected output:

```r
featureCV(msnset, factor(rep(1, nrow(msnset))), na.rm=TRUE)
#   CV.iTRAQ4.114 CV.iTRAQ4.115 CV.iTRAQ4.116 CV.iTRAQ4.117
# 1     0.4695498     0.2907382     0.4233534     0.5489767
```

I have rewritten the `featureCV` to fix this bug and to speed up the calculation a little bit (because of less loops).

I opened this PR because there are some failing unit tests (because my `pRolocdata` is too old) but I can't download a newer version now. Maybe you could have a look and run the tests.

