### PR TITLE
Read spectra data only once for MS1

### DIFF
--- a/R/readMSData.R
+++ b/R/readMSData.R
@@ -158,16 +158,17 @@ readMSData <- function(files,
                 if (verbose) setTxtProgressBar(pb, i)
                 j <- spidx[i]
                 hd <- fullhd[j,]
+                pks <- mzR::peaks(msdata, j)
                 sp <- new("Spectrum1",
                           peaksCount = hd$peaksCount,
                           rt = hd$retentionTime,
                           acquisitionNum = hd$acquisitionNum,
-                          mz = mzR::peaks(msdata,j)[,1],
-                          intensity = mzR::peaks(msdata,j)[,2],
+                          mz = pks[,1],
+                          intensity = pks[,2],
                           fromFile = filen,
                           tic = hd$totIonCurrent,
                           centroided = centroided)
-                ioncount[ioncounter] <- sum(mzR::peaks(msdata,j)[,2])
+                ioncount[ioncounter] <- sum(mks[,2])
                 ioncounter <- ioncounter + 1
                 if (removePeaks > 0)
                     sp <- removePeaks(sp, t=removePeaks)


### PR DESCRIPTION
Just replaced the 3 mzR::peaks calls for MS1 data reading with a single one, which speeds things up a little.

cheers, jo