### PR TITLE
Fix bug in normalize-MSnExp

### DIFF
--- a/R/functions-MSnExp.R
+++ b/R/functions-MSnExp.R
@@ -148,19 +148,22 @@ clean_MSnExp <- function(object, all, verbose = TRUE) {
 
 
 normalise_MSnExp <- function(object,method) {
-  sapply(featureNames(object),
-         function(x) {
-           sp <- get(x,envir=assayData(object))
-           xx <- normalise(sp,method)
-           assign(x,xx,envir=assayData(object))
-           invisible(TRUE)
-         })
-  object@processingData@processing <- c(object@processingData@processing,
-                                        paste0("Spectra normalised (",method,"): ",
-                                              date()))
-  object@processingData@normalised <- TRUE
-  if (validObject(object))
-    return(object)
+    ## Can not directly assign to assayData, as that environment is locked!
+    e <- new.env()
+    sapply(featureNames(object),
+           function(x) {
+               sp <- get(x,envir=assayData(object))
+               xx <- normalise(sp,method)
+               assign(x,xx,envir=e)
+               invisible(TRUE)
+           })
+    object@processingData@processing <- c(object@processingData@processing,
+                                          paste0("Spectra normalised (",method,"): ",
+                                                 date()))
+    object@processingData@normalised <- TRUE
+    object@assayData <- e
+    if (validObject(object))
+        return(object)
 }
 
 bin_MSnExp <- function(object, binSize=1, verbose=TRUE) {

--- a/R/readMSData.R
+++ b/R/readMSData.R
@@ -287,7 +287,8 @@ readMSData <- function(files,
     ## Create 'fdata' and 'pdata' objects
     nms <- ls(assaydata)
     if (is.null(pdata)) {
-        .pd <- data.frame(sampleNames = 1)
+        .pd <- data.frame(sampleNames = basename(files))
+        rownames(.pd) <- basename(files)
         pdata <- new("NAnnotatedDataFrame",
                      data = .pd)
     }


### PR DESCRIPTION
o Fix a bug in normalize method for MSnExp objects: assigning normalized
  spectra directly to assayData is not possible, as the environment is
  locked.
o readMSData: if no phenodata is provided it creates an empty one with
  rownames corresponding to the file names.