### PR TITLE
Add $,pSet method to easily access columns in the phenoData

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -267,7 +267,10 @@ exportMethods(updateObject,
               ## MzTab
               fileName,
               metadata,
-              psms)
+              psms,
+              pData, "pData<-",
+              "$",
+              "$<-")
 
 ## methods NOT exported
 ## curveStats

--- a/R/methods-pSet.R
+++ b/R/methods-pSet.R
@@ -536,6 +536,19 @@ setMethod("spectrapply", "pSet", function(object, FUN = NULL,
     return(vals)
 })
 
+setMethod("$", "pSet", function(x, name) {
+    eval(substitute(pData(x)$NAME_ARG, list(NAME_ARG = name)))
+})
+setReplaceMethod("$", "pSet", function(x, name, value) {
+    pData(x)[[name]] <- value
+    x
+})
+
+setReplaceMethod("pData", "pSet", function(object, value) {
+    pData(object@phenoData) <- value
+    object
+})
+
 ################################
 ## TODO: setReplaceMethods for
 ##  phenoData

--- a/man/pSet-class.Rd
+++ b/man/pSet-class.Rd
@@ -10,6 +10,8 @@
 \alias{[,pSet,ANY,ANY,ANY-method}
 \alias{[[,pSet-method}
 \alias{[[,pSet,ANY,ANY-method}
+\alias{$,pSet-method}
+\alias{$<-,pSet-method}
 \alias{abstract,pSet-method}
 \alias{acquisitionNum,pSet-method}
 \alias{scanIndex,pSet-method}
@@ -44,6 +46,7 @@
 \alias{mz,pSet-method}
 \alias{notes,pSet-method}
 \alias{pData,pSet-method}
+\alias{pData<-,pSet,ANY-method}
 \alias{peaksCount,pSet,missing-method}
 \alias{peaksCount,pSet,numeric-method}
 \alias{phenoData,pSet-method}
@@ -151,6 +154,10 @@
       return object of same class. }
     \item{[[}{\code{signature(x = "pSet")}: Direct access to individual
       spectra. }
+    \item{$}{\code{signature(x = "pSet")}: directly access a specific
+    sample annotation column from the \code{pData}.}
+    \item{$<-}{\code{signature(x = "pSet")}: replace or add a
+    sample annotation column in the \code{pData}.}
     \item{abstract}{Access abstract in \code{experimentData}. }
     \item{assayData}{\code{signature(object = "pSet")}: Access the
       \code{assayData} slot. Returns an \code{environment}. }
@@ -193,6 +200,8 @@
     \code{experimentData} slot. }
     \item{pData}{\code{signature(x = "pSet")}: Access sample data
       information. }
+    \item{pData<-}{\code{signature(x = "pSet", value)}: Replace sample data
+      information with \code{value}. }
     \item{phenoData}{\code{signature(x = "pSet")}: Access the
       \code{phenoData} slot. }
     \item{processingData}{\code{signature(object = "pSet")}: Access the

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -361,3 +361,28 @@ test_that("splitByFile,MSnExp", {
     expect_equal(spectra(spl[[2]]), spectra(filterFile(inMem, 1)))
     expect_equal(pData(spl[[2]]), pData(filterFile(inMem, 1)))    
 })
+
+test_that("$ operator on MSnExp works", {
+    f <- dir(system.file(package = "MSnbase", dir = "extdata"),
+             full.name = TRUE, pattern = "msx.rda")
+    load(f) ## msx
+    expect_equal(pData(msx)$sampleNames, msx$sampleNames)
+    ## replace.
+    msx$sampleNames <- "b"
+    expect_equal("b", msx$sampleNames)
+    expect_equal(msx$bla, NULL)
+    ## Add a new column
+    msx$newCol <- 5
+    expect_equal(msx$newCol, 5)
+})
+
+test_that("pData<- on MSnExp works", {
+    f <- dir(system.file(package = "MSnbase", dir = "extdata"),
+             full.name = TRUE, pattern = "msx.rda")
+    load(f) ## msx
+
+    newDf <- data.frame(sampleName = "b", otherCol = 3)
+    ## replace.
+    pData(msx) <- newDf
+    expect_equal(pData(msx), newDf)
+})


### PR DESCRIPTION
- Add $, $<- and pData<- methods to easily get and replace/add columns to the
  phenodata.
- Add related unit tests and add documentation.

Basically, It facilitates accessing pheno data columns by just calling `pset$pheno_col`. I find that pretty convenient e.g. in `ExpressionSet` objects and alike, so I thought it might be nice to have it in `MSnbase` as well.
Also I added replace methods for the `pData`.