### PR TITLE
Add "normalise to reference run (per protein)" function.

### DIFF
--- a/R/functions-MSnSet.R
+++ b/R/functions-MSnSet.R
@@ -33,7 +33,7 @@ normalise_MSnSet <- function(object, method, ...) {
       e <- sweep(e, 2L, cmeds - med)
   } else {
     switch(method,
-           max = div <- apply(exprs(object), 1L, max, na.rm = TRUE),
+           max = div <- .rowMaxs(exprs(object), na.rm = TRUE),
            sum = div <- rowSums(exprs(object), na.rm = TRUE))
     e <- exprs(object)/div
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -289,6 +289,22 @@ getVariableName <- function(match_call, varname) {
   tail(as.character(mcx), n = 1)
 }
 
+#' rowwise max, similar to rowwise mean via rowMeans
+#'
+#' @param x matrix
+#' @param na.rm logical
+#' @return double vector with maximum values per row
+#' @seealso Biobase::rowMax (could not handle missing values/NA)
+#' @noRd
+.rowMaxs <- function(x, na.rm=FALSE) {
+  stopifnot(is.matrix(x))
+  if (na.rm) {
+    x[is.na(x)] <- -Inf
+  }
+  nr <- nrow(x)
+  x[(max.col(x, ties.method="first") - 1L) * nr + 1L:nr]
+}
+
 #' summarise rows by an user-given function
 #'
 #' @param x matrix

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -262,6 +262,15 @@ test_that("Get first MS level", {
     expect_equivalent(y1, y2)
 })
 
+test_that(".rowMaxs", {
+  m <- matrix(1:30, nrow=10)
+  m[c(2, 5:6, 10, 12:14, 21:25)] <- NA
+  expect_error(MSnbase:::.rowMaxs(1:10))
+  expect_equal(MSnbase:::.rowMaxs(m), apply(m, 1, max))
+  expect_equal(MSnbase:::.rowMaxs(m, na.rm=TRUE),
+               suppressWarnings(apply(m, 1, max, na.rm=TRUE)))
+})
+
 test_that(".summariseRows", {
   m <- matrix(1:30, nrow=10)
   m[seq(2, 30, by=3)] <- NA

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -297,3 +297,33 @@ test_that(".topIdx", {
   expect_equal(MSnbase:::.topIdx(m, groupBy=g, fun=sum, n=2),
                c(10, 7, 8, 5, 9, 6))
 })
+
+test_that(".referenceFraction", {
+  m <- matrix(c(1, 1, 2, NA,
+                2, 2, 3, 1,
+                1, NA, NA, NA,
+                2, 2, NA, 2,
+                NA, 3, 3, 4), nrow=5, byrow=TRUE,
+              dimnames = list(paste0("P", 1:5), paste0("F", 1:4)))
+
+  group <- c("J", "J", "G", "G", "G")
+  expect_equal(MSnbase:::.referenceFraction(m, group), c(J=3, G=4))
+})
+
+test_that(".normToReferenceFraction", {
+  m <- matrix(c(1, 1, 2, NA,
+                2, 2, 3, 1,
+                1, NA, NA, NA,
+                2, 2, NA, 2,
+                NA, 3, 3, 4), nrow=5, byrow=TRUE,
+              dimnames = list(paste0("P", 1:5), paste0("F", 1:4)))
+
+  group <- c("J", "J", "G", "G", "G")
+
+  r <- matrix(c(3/5, 3/5, 1, 1/3,
+                1, 5/6, 3/4, 1), nrow=2, byrow=TRUE,
+              dimnames = list(c("J", "G"), paste0("F", 1:4)))
+
+  expect_equal(MSnbase:::.normToReferenceFraction(m, group), r/c(38/15, 43/12))
+  expect_equal(MSnbase:::.normToReferenceFraction(m, group, norm=FALSE), r)
+})


### PR DESCRIPTION
This PR should introduce another normalisation/label free quantitation method.

It is described in: https://doi.org/10.1104/pp.114.245589

> The peptide data were converted to protein intensities as follows. For each protein, a fraction with the highest number of peptides quantified was nominated as a reference fraction. The protein abundance in that reference fraction was taken as one. Then, other fractions were quantified against the reference fraction by finding the ratio of the combined intensity for peptides shared between the interrogated and reference fractions. When the quantities in all fractions for a given protein were computed, the values were renormalized to give a sum = 1 across all 10 fractions.

It was already implemented by @lgatto in https://github.com/lgatto/pRoloc/blob/master/R/lopims.R#L80-L127. And we need it in our current *synapter*/LOPIMS analysis.

I like to rewrite it (add some unit tests etc.). IMHO it is not only useful for organelle proteomics or *pRoloc* users, so I think *MSnbase* would be the right place for this method.

While having a prototype of the workhorse functions I was wondering what would be the right top-level API for such a function. It is similar to the TOP3 approach which is run in the following way:
```r
## extract top 3 peptides
msnset <- topN(msnset, groupBy=proteinAccession, n=3)

## calculate the number of peptides that are available
nPeps <- nQuants(msnset, groupBy=proteinAccession)

## sum top3 peptides into protein quantitation
msnset <- combineFeatures(msnset, groupBy=proteinAccession, fun="sum", na.rm=TRUE)

## adjust protein intensity based on actual
## number of top peptides
exprs(msnset) <- exprs(msnset) * (3/nPeps)
```
A `normToReference` function would internally convert a `MSnSet` of peptides into an `MSnSet` of proteins with its own functions. There is no simple `combineFeatures` method aka `sum` because the reference run is different for each protein and the number of summed peptides could be different for each run within each protein (so even `nQuants` would need a different implementation). So it would be more like:
```r
msnset <- normToReference(msnset, groupBy=proteinAccession)
```

So before working on a `normToReference` function I would like to ask the following questions:

1. Which kind of high-level (user-visible) API I should use/provide?
2. @lgatto Do you want to have this function in *MSnbase* (or keep it in *pRoloc*)?
3. Currently everything is in `utils.R`. Is there a better file for it?
4. Any ideas for a better name?