### PR TITLE
nQuant/featureCV return wrong sized matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Changes in version 2.3.1
 
 - Introduce "NTR" method for `combineFeatures` <2017-04-26 Wed>.
+- Rewrite `nQuants` and `featureCV` to avoid returning of rows for empty
+    factors; see PR #208 for details <2017-04-28 Fri>.
 
 ## Changes in version 2.3.0
 

--- a/R/functions-MSnSet.R
+++ b/R/functions-MSnSet.R
@@ -81,12 +81,10 @@ featureCV <- function(x, groupBy, na.rm = TRUE,
   if (norm != "none")
     x <- normalise(x, method = norm)
 
-  ans <- utils.applyColumnwiseByGroup(exprs(x), groupBy=groupBy,
-                                      FUN=function(y, ...) {
-                                        utils.colSd(y, ...)/
-                                          colMeans(y, ...)}, na.rm=na.rm)
-  colnames(ans) <- paste("CV", colnames(ans), sep = ".")
-  ans
+  cv <- rowsd(exprs(x), group=groupBy, reorder=TRUE, na.rm=na.rm) /
+          rowmean(exprs(x), group=groupBy, reorder=TRUE, na.rm=na.rm)
+  colnames(cv) <- paste("CV", colnames(cv), sep=".")
+  cv
 }
 
 updateFvarLabels <- function(object, label, sep = ".") {

--- a/R/functions-MSnSet.R
+++ b/R/functions-MSnSet.R
@@ -158,11 +158,9 @@ nQuants <- function(x, groupBy) {
   if (class(x) != "MSnSet")
     stop("'x' must be of class 'MSnSet'.")
 
-  ans <- utils.applyColumnwiseByGroup(exprs(x), groupBy=groupBy,
-                                      FUN=function(y) {
-                                        nrow(y)-colSums(is.na(y))})
-  colnames(ans) <- sampleNames(x)
-  ans
+  e <- !is.na(exprs(x))
+  mode(e) <- "numeric"
+  rowsum(e, group=groupBy, reorder=TRUE)
 }
 
 ##' Subsets \code{MSnSet} instances to their common feature names.

--- a/R/utils.R
+++ b/R/utils.R
@@ -919,6 +919,30 @@ rowmean <- function(x, group, reorder=FALSE, na.rm=FALSE) {
   rs/nna
 }
 
+##' Similar to rowsum but calculates the sd.
+##' See ?rowsum for details.
+##' @param x matrix
+##' @param group a vector/factor of grouping
+##' @param reorder if TRUE the rows are ordered by `sort(unique(group))`
+##' @param na.rm logical. Should missing values (including ‘NaN’) be omitted
+##' @return matrix
+##' @author Sebastian Gibb <mail@@sebastiangibb.de>
+##' @noRd
+rowsd <- function(x, group, reorder=FALSE, na.rm=FALSE) {
+  if (na.rm) {
+    nna <- !is.na(x)
+    mode(nna) <- "numeric"
+  } else {
+    nna <- x
+    nna[] <- 1
+  }
+  nna <- rowsum(nna, group=group, reorder=reorder, na.rm=na.rm)
+  nna[nna == 1] <- NA_real_            # return NA if n == 1 (similar to sd)
+  var <- rowmean(x*x, group=group, reorder=reorder, na.rm=na.rm) -
+    rowmean(x, group=group, reorder=reorder, na.rm=na.rm)^2L
+  sqrt(var * nna/(nna - 1L))
+}
+
 ##' Apply a function groupwise. Similar to tapply but takes a matrix as input
 ##' and preserve its structure and order.
 ##' @title applyColumnwiseByGroup

--- a/R/utils.R
+++ b/R/utils.R
@@ -943,36 +943,6 @@ rowsd <- function(x, group, reorder=FALSE, na.rm=FALSE) {
   sqrt(var * nna/(nna - 1L))
 }
 
-##' Apply a function groupwise. Similar to tapply but takes a matrix as input
-##' and preserve its structure and order.
-##' @title applyColumnwiseByGroup
-##' @param x matrix
-##' @param groupBy factor/grouping index
-##' @param FUN function to be applied; must work on columns, e.g. colSums
-##' @param ... further arguments to FUN
-##' @return modified matrix
-##' @author Sebastian Gibb <mail@@sebastiangibb.de>
-##' @noRd
-utils.applyColumnwiseByGroup <- function(x, groupBy, FUN, ...) {
-  if (!is.matrix(x)) {
-    stop("x has to be a matrix!")
-  }
-
-  groupBy <- as.factor(groupBy)
-  FUN <- match.fun(FUN)
-
-  j <- split(1L:nrow(x), groupBy)
-  ans <- matrix(NA_real_, nrow = nlevels(groupBy), ncol = ncol(x),
-                dimnames = list(levels(groupBy), colnames(x)))
-
-  for (i in seq(along = j)) {
-    subexprs <- x[j[[i]], , drop = FALSE]
-    ans[i, ] <- do.call(FUN, list(subexprs, ...))
-  }
-
-  ans
-}
-
 setMethod("trimws", "data.frame",
           function(x, which, ...) {
               for (i in 1:ncol(x)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -897,6 +897,28 @@ utils.colSd <- function(x, na.rm = TRUE) {
   sqrt(colVar * n/(n - 1L))
 }
 
+##' Similar to rowsum but calculates the mean. It is slower than colMeans but
+##' supports grouping variables. See ?rowsum for details.
+##' @param x matrix
+##' @param group a vector/factor of grouping
+##' @param reorder if TRUE the rows are ordered by `sort(unique(group))`
+##' @param na.rm logical. Should missing values (including ‘NaN’) be omitted
+##' @return matrix
+##' @author Sebastian Gibb <mail@@sebastiangibb.de>
+##' @noRd
+rowmean <- function(x, group, reorder=FALSE, na.rm=FALSE) {
+  if (na.rm) {
+    nna <- !is.na(x)
+    mode(nna) <- "numeric"
+  } else {
+    nna <- x
+    nna[] <- 1
+  }
+  nna <- rowsum(nna, group=group, reorder=reorder, na.rm=na.rm)
+  rs <- rowsum(x, group=group, reorder=reorder, na.rm=na.rm)
+  rs/nna
+}
+
 ##' Apply a function groupwise. Similar to tapply but takes a matrix as input
 ##' and preserve its structure and order.
 ##' @title applyColumnwiseByGroup

--- a/R/utils.R
+++ b/R/utils.R
@@ -877,26 +877,6 @@ compareMSnSets <- function(x, y, qual = FALSE, proc = FALSE) {
     all.equal(x, y)
 }
 
-##' Similar to colMeans but calculates the sd. Should be identical to
-##' apply(x, 2, sd, na.rm).
-##' based on: http://stackoverflow.com/questions/17549762/is-there-such-colsd-in-r/17551600#17551600
-##' @title colSd
-##' @param x matrix/data.frame
-##' @param na.rm logical. Should missing values (including ‘NaN’) be omitted
-##' from the calculations?
-##' @return double
-##' @author Sebastian Gibb <mail@@sebastiangibb.de>
-##' @noRd
-utils.colSd <- function(x, na.rm = TRUE) {
-  if (na.rm) {
-    n <- colSums(!is.na(x))
-  } else {
-    n <- nrow(x)
-  }
-  colVar <- colMeans(x*x, na.rm = na.rm) - (colMeans(x, na.rm = na.rm))^2L
-  sqrt(colVar * n/(n - 1L))
-}
-
 ##' Similar to rowsum but calculates the mean. It is slower than colMeans but
 ##' supports grouping variables. See ?rowsum for details.
 ##' @param x matrix

--- a/tests/testthat/test_MSnSet.R
+++ b/tests/testthat/test_MSnSet.R
@@ -247,6 +247,31 @@ test_that("nQuants", {
     expect_equal(nQuants(msnset[1:10], pa[1:10]), qu)
 })
 
+test_that("featureCV", {
+    m <- new("MSnSet",
+             exprs=matrix(1:10, nrow=5, ncol=2),
+             featureData=new("AnnotatedDataFrame",
+                             data=data.frame(accession=
+                                             factor(c("A", "A", "A", "B", "B")))))
+    cv <- matrix(c(0.5, 1/4.5, 1/7, 1/9.5),
+                 nrow=2, ncol=2, dimnames=list(c("A", "B"), c("CV.1", "CV.2"))
+    expect_equal(featureCV(m, group=fData(m)$accession, norm="none"), cv)
+
+    ## more levels than items present in the factor
+    m@featureData <- new("AnnotatedDataFrame",
+                         data=data.frame(accession=
+                                         factor(c("A", "A", "A", "B", "B"),
+                                                    levels=LETTERS[1:10])))
+    expect_equal(featureCV(m, group=fData(m)$accession, norm="none"), cv)
+
+    i <- list(1:3, 4:5, 6:8, 9:10)
+    div <- rowSums(exprs(m))
+    cv <- matrix(sapply(i, function(ii) {
+                   sd((exprs(m)/div)[ii]/mean((exprs(m)/div)[ii])) }),
+                 nrow=2, ncol=2, dimnames=list(c("A", "B"), c("CV.1", "CV.2")))
+    expect_equal(featureCV(m, group=fData(m)$accession, norm="sum"), cv)
+})
+
 context("MSnSet identification data")
 
 test_that("addIdentificationData", {

--- a/tests/testthat/test_MSnSet.R
+++ b/tests/testthat/test_MSnSet.R
@@ -212,6 +212,19 @@ test_that("Transpose and subset", {
     expect_identical(dim(bb), c(2L, 2L))
 })
 
+test_that("nQuants", {
+    data(msnset)
+    pa <- fData(msnset)$ProteinAccession
+    upa <- unique(pa)
+    qu <- matrix(1, nrow=length(upa), ncol=ncol(msnset),
+                 dimnames=list(upa[order(upa)], sampleNames(msnset)))
+    qu[c("ECA0435", "ECA0469", "ECA3349", "ECA3566", "ECA4026"),] <- 2
+    qu["BSA",] <- 3
+    qu["ENO",] <- c(4, 4, 3, 4)
+    qu["ECA4514",] <- 6
+    expect_equal(nQuants(msnset, pa), qu)
+})
+
 context("MSnSet identification data")
 
 test_that("addIdentificationData", {

--- a/tests/testthat/test_MSnSet.R
+++ b/tests/testthat/test_MSnSet.R
@@ -213,6 +213,22 @@ test_that("Transpose and subset", {
 })
 
 test_that("nQuants", {
+    m <- new("MSnSet",
+             exprs=matrix(1:10, nrow=5, ncol=2),
+             featureData=new("AnnotatedDataFrame",
+                             data=data.frame(accession=
+                                             factor(c("A", "A", "A", "B", "B")))))
+    qu <- matrix(3:2, nrow=2, ncol=2, dimnames=list(c("A", "B"), 1:2))
+    expect_equal(nQuants(m, group=fData(m)$accession), qu)
+
+    ## more levels than items present in the factor
+    m@featureData <- new("AnnotatedDataFrame",
+                         data=data.frame(accession=
+                                         factor(c("A", "A", "A", "B", "B"),
+                                                    levels=LETTERS[1:10])))
+    expect_equal(nQuants(m, group=fData(m)$accession), qu)
+
+    ## real world example
     data(msnset)
     pa <- fData(msnset)$ProteinAccession
     upa <- unique(pa)
@@ -223,6 +239,12 @@ test_that("nQuants", {
     qu["ENO",] <- c(4, 4, 3, 4)
     qu["ECA4514",] <- 6
     expect_equal(nQuants(msnset, pa), qu)
+
+    ## more levels than items present in the factor
+    qu <- matrix(1, nrow=10, ncol=4,
+                 dimnames=list(as.character(pa[order(pa[1:10])]),
+                                            sampleNames(msnset)))
+    expect_equal(nQuants(msnset[1:10], pa[1:10]), qu)
 })
 
 context("MSnSet identification data")

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -172,6 +172,21 @@ test_that("colSd", {
                  apply(mna, 2, sd, na.rm=TRUE))
 })
 
+test_that("rowmean", {
+    m <- matrix(1:10, ncol=2)
+    mna <- m
+    mna[c(2, 8)] <- NA
+    group <- c("B", "B", "A", "A", "B")
+    r <- matrix(c(8/3, 3.5, 23/3, 8.5), ncol=2, dimnames=list(c("B", "A"), c()))
+    rna <- matrix(c(NA, 3.5, 23/3, NA), ncol=2, dimnames=list(c("B", "A"), c()))
+    rnarm <- matrix(c(3, 3.5, 23/3, 9), ncol=2, dimnames=list(c("B", "A"), c()))
+    expect_equal(MSnbase:::rowmean(m, group=group), r)
+    expect_equal(MSnbase:::rowmean(m, group=group, reorder=TRUE), r[2:1,])
+    expect_equal(MSnbase:::rowmean(mna, group=group), rna)
+    expect_equal(MSnbase:::rowmean(mna, group=group, reorder=TRUE), rna[2:1,])
+    expect_equal(MSnbase:::rowmean(mna, group=group, na.rm=TRUE), rnarm)
+})
+
 test_that("applyColumnwiseByGroup", {
     m <- matrix(1:20, nrow=4, byrow=TRUE,
                 dimnames=list(1:4, LETTERS[1:5]))

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -162,16 +162,6 @@ test_that("formatRt", {
     expect_warning(is.na(formatRt(TRUE)))
 })
 
-test_that("colSd", {
-    set.seed(1)
-    m <- matrix(rnorm(10), ncol=2)
-    mna <- m
-    mna[c(1, 8)] <- NA
-    expect_equal(MSnbase:::utils.colSd(m), apply(m, 2, sd))
-    expect_equal(MSnbase:::utils.colSd(mna, na.rm=TRUE),
-                 apply(mna, 2, sd, na.rm=TRUE))
-})
-
 test_that("rowmean", {
     m <- matrix(1:10, ncol=2)
     mna <- m

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -178,13 +178,36 @@ test_that("rowmean", {
     mna[c(2, 8)] <- NA
     group <- c("B", "B", "A", "A", "B")
     r <- matrix(c(8/3, 3.5, 23/3, 8.5), ncol=2, dimnames=list(c("B", "A"), c()))
-    rna <- matrix(c(NA, 3.5, 23/3, NA), ncol=2, dimnames=list(c("B", "A"), c()))
+    rna <- r
+    rna[c(1, 4)] <- NA
     rnarm <- matrix(c(3, 3.5, 23/3, 9), ncol=2, dimnames=list(c("B", "A"), c()))
+    expect_error(MSnbase:::rowmean(m, group=1:2))
     expect_equal(MSnbase:::rowmean(m, group=group), r)
     expect_equal(MSnbase:::rowmean(m, group=group, reorder=TRUE), r[2:1,])
     expect_equal(MSnbase:::rowmean(mna, group=group), rna)
     expect_equal(MSnbase:::rowmean(mna, group=group, reorder=TRUE), rna[2:1,])
     expect_equal(MSnbase:::rowmean(mna, group=group, na.rm=TRUE), rnarm)
+})
+
+test_that("rowsd", {
+    m <- matrix(1:10, ncol=2)
+    mna <- m
+    mna[c(2, 8)] <- NA
+    group <- c("B", "B", "A", "A", "B")
+    r <- matrix(c(sd(m[c(1, 2, 5), 1]), sd(m[3:4, 1]),
+                  sd(m[c(1, 2, 5), 2]), sd(m[3:4, 2])),
+                  ncol=2, dimnames=list(c("B", "A"), c()))
+    rna <- r
+    rna[c(1, 4)] <- NA
+    rnarm <- matrix(c(sd(mna[c(1, 2, 5), 1], na.rm=TRUE), r[2],
+                      r[3], sd(mna[3:4, 2], na.rm=TRUE)),
+          ncol=2, dimnames=list(c("B", "A"), c()))
+    expect_error(MSnbase:::rowsd(m, group=1:2))
+    expect_equal(MSnbase:::rowsd(m, group=group), r)
+    expect_equal(MSnbase:::rowsd(m, group=group, reorder=TRUE), r[2:1,])
+    expect_equal(MSnbase:::rowsd(mna, group=group), rna)
+    expect_equal(MSnbase:::rowsd(mna, group=group, reorder=TRUE), rna[2:1,])
+    expect_equal(MSnbase:::rowsd(mna, group=group, na.rm=TRUE), rnarm)
 })
 
 test_that("applyColumnwiseByGroup", {

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -210,18 +210,6 @@ test_that("rowsd", {
     expect_equal(MSnbase:::rowsd(mna, group=group, na.rm=TRUE), rnarm)
 })
 
-test_that("applyColumnwiseByGroup", {
-    m <- matrix(1:20, nrow=4, byrow=TRUE,
-                dimnames=list(1:4, LETTERS[1:5]))
-    r <- matrix(c(seq(7, 15, by=2), seq(27, 35, by=2)), nrow=2, byrow=TRUE,
-                dimnames=list(1:2, LETTERS[1:5]))
-    expect_error(MSnbase:::utils.applyColumnwiseByGroup(1:10, 1:2, sum),
-                 "x has to be a matrix")
-    expect_equal(MSnbase:::utils.applyColumnwiseByGroup(m,
-                                                        rep(1:2, each=2),
-                                                        colSums), r)
-})
-
 test_that("get.amino.acids", {
     aa <- get.amino.acids()
     cn <- c("AA", "ResidueMass", "Abbrev3", "ImmoniumIonMass", "Name",


### PR DESCRIPTION
This PR fixes `nQuant` and `featureCV`. Both functions return a wrong-sized matrix if the grouping variable is a `factor` that contains more `levels` than items:
MWE:
```r
library("MSnbase")

m <- new("MSnSet",
         exprs=matrix(1:10, nrow=5, ncol=2),
         featureData=new("AnnotatedDataFrame",
                         data=data.frame(accession=
                                         factor(c("A", "A", "A", "B", "B"),
                                                levels=LETTERS[1:10]))))
exprs(m)
#   1  2
# 1 1  6
# 2 2  7
# 3 3  8
# 4 4  9
# 5 5 10

nQuants(m, fData(m)$accession)
#   1 2
# A 3 3
# B 2 2
# C 0 0
# D 0 0
# E 0 0
# F 0 0
# G 0 0
# H 0 0
# I 0 0
# J 0 0
```
This results in an error if you want to apply *TOP3* quantitation after you did some subsetting (e.g. filtering):

```r
library("MSnbase")
data(msnset)

nQuants(msnset, fData(msnset)$ProteinAccession)
#         iTRAQ4.114 iTRAQ4.115 iTRAQ4.116 iTRAQ4.117
# BSA              3          3          3          3
# ECA0172          1          1          1          1
# ECA0435          2          2          2          2
# ...
# ECA4514          6          6          6          6
# ENO              4          4          3          4

msnsetSubset <- msnset[1:5]
nQuants(msnsetSubset, fData(msnsetSubset)$ProteinAccession)
#         iTRAQ4.114 iTRAQ4.115 iTRAQ4.116 iTRAQ4.117
# BSA              1          1          1          1
# ECA0172          0          0          0          0
# ECA0435          0          0          0          0
# ...
# ECA4514          0          0          0          0
# ENO              0          0          0          0


msnsetSubsetTop3 <- topN(msnsetSubset,
                         groupBy=fData(msnsetSubset)$ProteinAccession,
                         n=3)
nSubsetPeps <- nQuants(msnsetSubsetTop3,
                       groupBy=fData(msnsetSubset)$ProteinAccession)
msnsetSubsetTop3 <- combineFeatures(msnsetSubsetTop3,
                                    groupBy=fData(msnsetSubset)$ProteinAccession,
                                    fun="sum", na.rm=TRUE)

exprs(msnsetSubsetTop3) <- exprs(msnsetSubsetTop3) * (3/nSubsetPeps)
# Error in exprs(msnsetSubsetTop3) * (3/nSubsetPeps) :
#  non-conformable arrays
```

This PR removes `utils.colSd`, `utils.applyColumnwiseByGroup`, rewrites `nQuants`, `featureCV`, adds `rowmean`, `rowsd` (both similar to `rowsum`) and adds unit tests for all of them.

As side-effect it changes the output of `nQuants` and `featureCV`. Now they return a matrix with `nrow(x) == sum(levels(group) %in% group)` instead of `nrow(x) == nlevels(group)`. I don't think anybody would use the former output format. In the current phase of the release cycle it should be safe to change the dimension of the return values.

Same example as above with the new implementation:
```r
library("MSnbase")
data(msnset)

nQuants(msnset, fData(msnset)$ProteinAccession)
#         iTRAQ4.114 iTRAQ4.115 iTRAQ4.116 iTRAQ4.117
# BSA              3          3          3          3
# ECA0172          1          1          1          1
# ECA0435          2          2          2          2
# ...
# ECA4514          6          6          6          6
# ENO              4          4          3          4

msnsetSubset <- msnset[1:5]
nQuants(msnsetSubset, fData(msnsetSubset)$ProteinAccession)
#         iTRAQ4.114 iTRAQ4.115 iTRAQ4.116 iTRAQ4.117
# BSA              1          1          1          1
# ECA1364          1          1          1          1
# ECA1422          1          1          1          1
# ECA3882          1          1          1          1
# ECA4030          1          1          1          1

msnsetSubsetTop3 <- topN(msnsetSubset,
                         groupBy=fData(msnsetSubset)$ProteinAccession,
                         n=3)
nSubsetPeps <- nQuants(msnsetSubsetTop3,
                       groupBy=fData(msnsetSubset)$ProteinAccession)
msnsetSubsetTop3 <- combineFeatures(msnsetSubsetTop3,
                                    groupBy=fData(msnsetSubset)$ProteinAccession,
                                    fun="sum", na.rm=TRUE)

exprs(msnsetSubsetTop3) <- exprs(msnsetSubsetTop3) * (3/nSubsetPeps)
msnsetSubsetTop3
# MSnSet (storageMode: lockedEnvironment)
# assayData: 5 features, 4 samples
#   element names: exprs
# protocolData: none
# phenoData: none
# featureData
#   featureNames: BSA ECA1364 ... ECA4030 (5 total)
#   fvarLabels: spectrum ProteinAccession ... CV.iTRAQ4.117 (19 total)
#   fvarMetadata: labelDescription
# experimentData: use 'experimentData(object)'
# Annotation:
# - - - Processing information - - -
# Data loaded: Wed May 11 18:54:39 2011
# iTRAQ4 quantification by trapezoidation: Wed Apr  1 21:41:53 2015
# Subset [55,4][5,4] Fri Apr 28 18:13:18 2017
# Selected top 3 features [Fri Apr 28 18:13:57 2017]
# Subset [5,4][5,4] Fri Apr 28 18:13:57 2017
# Combined 5 features into 5 using sum: Fri Apr 28 18:13:57 2017
#  MSnbase version: 2.3.1
```