### PR TITLE
Switch mzR backend based on data type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.3.3
+Version: 2.3.4
 Description: Manipulation, processing and visualisation
     of mass spectrometry and proteomics data.
 Authors@R: c(person(given = "Laurent", family = "Gatto",

--- a/R/functions-OnDiskMSnExp.R
+++ b/R/functions-OnDiskMSnExp.R
@@ -232,11 +232,8 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
     if (missing(fData) | missing(filenames))
         stop("Both 'fData' and 'filenames' are required!")
     filename <- filenames[fData[1, "fileIdx"]]
-    ## Open the file.
-    if (isCdfFile(filename))
-        fileh <- mzR::openMSfile(filename, backend = "netCDF")
-    else
-        fileh <- mzR::openMSfile(filename)
+    ## issue #214: define backend based on file format.
+    fileh <- mzR::openMSfile(filename, backend = mzRBackend(filename))
     ## hd <- header(fileh)
     on.exit(expr = mzR::close(fileh))
     ## Intermediate #151 fix. Performance-wise would be nice to get rid of this.

--- a/R/functions-OnDiskMSnExp.R
+++ b/R/functions-OnDiskMSnExp.R
@@ -233,7 +233,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
         stop("Both 'fData' and 'filenames' are required!")
     filename <- filenames[fData[1, "fileIdx"]]
     ## issue #214: define backend based on file format.
-    fileh <- mzR::openMSfile(filename, backend = mzRBackend(filename))
+    fileh <- .openMSfile(filename)
     ## hd <- header(fileh)
     on.exit(expr = mzR::close(fileh))
     ## Intermediate #151 fix. Performance-wise would be nice to get rid of this.
@@ -369,7 +369,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
         stop("Both 'fData' and 'filenames' are required!")
     filename <- filenames[fData[1, "fileIdx"]]
     ## Open the file.
-    fileh <- mzR::openMSfile(filename)
+    fileh <- .openMSfile(filename)
     hd <- header(fileh)
     on.exit(expr = mzR::close(fileh))
     msLevel1 <- which(fData$msLevel == 1)

--- a/R/methods-mzR.R
+++ b/R/methods-mzR.R
@@ -43,7 +43,7 @@ setMethod("chromatogram", "character",
                    plot = TRUE,
                    ms = 1L,
                    ...) {
-              object <- openMSfile(object)
+              object <- .openMSfile(object)
               on.exit(close(object))
               hd <- header(object)
               f <- basename(fileName(object))
@@ -88,6 +88,6 @@ setMethod("xic", "mzRramp",
 
 setMethod("xic", "character",
           function(object, ...) {
-              object <- openMSfile(object)
+              object <- .openMSfile(object)
               xic_1(object, ...)
           })

--- a/R/quantitation-MS2-isobaric.R
+++ b/R/quantitation-MS2-isobaric.R
@@ -84,7 +84,7 @@ quantify_MSnExp <- function(object, method,
 ## spectra spi in file f using max of peak (irrespective if spectrum
 ## is centroided or profile mode)
 fastquant_max <- function(f, pk, spi, wd = 0.5) {
-    ramp <- openMSfile(f)
+    ramp <- .openMSfile(f)
     on.exit(close(ramp))
     pks <- peaks(ramp, spi)
     if (length(spi) == 1)

--- a/R/readMSData.R
+++ b/R/readMSData.R
@@ -29,10 +29,8 @@ readMSData <- function(files,
         filen <- match(f, files)
         filenums <- c(filenums, filen)
         filenams <- c(filenams, f)
-        if (isCdfFile(f))
-            msdata <- mzR::openMSfile(f, backend = "netCDF")
-        else
-            msdata <- mzR::openMSfile(f)
+        ## issue #214: define backend based on file format.
+        msdata <- mzR::openMSfile(f, backend = mzRBackend(f))
         .instrumentInfo <- c(.instrumentInfo, list(instrumentInfo(msdata)))
         fullhd <- mzR::header(msdata)
         spidx <- which(fullhd$msLevel == msLevel.)

--- a/R/readMSData.R
+++ b/R/readMSData.R
@@ -30,7 +30,7 @@ readMSData <- function(files,
         filenums <- c(filenums, filen)
         filenams <- c(filenams, f)
         ## issue #214: define backend based on file format.
-        msdata <- mzR::openMSfile(f, backend = mzRBackend(f))
+        msdata <- .openMSfile(f)
         .instrumentInfo <- c(.instrumentInfo, list(instrumentInfo(msdata)))
         fullhd <- mzR::header(msdata)
         spidx <- which(fullhd$msLevel == msLevel.)

--- a/R/readMSData2.R
+++ b/R/readMSData2.R
@@ -25,7 +25,7 @@ readMSData2 <- function(files,
         filenums <- c(filenums, filen)
         filenams <- c(filenams, f)
         ## issue #214: define backend based on file format.
-        msdata <- mzR::openMSfile(f, backend = mzRBackend(f))
+        msdata <- .openMSfile(f)
         .instrumentInfo <- c(.instrumentInfo, list(instrumentInfo(msdata)))
         fullhd <- mzR::header(msdata)
         spidx <- seq_len(nrow(fullhd))

--- a/R/readMSData2.R
+++ b/R/readMSData2.R
@@ -24,10 +24,8 @@ readMSData2 <- function(files,
         filen <- match(f, files)
         filenums <- c(filenums, filen)
         filenams <- c(filenams, f)
-        if (isCdfFile(f))
-            msdata <- mzR::openMSfile(f, backend = "netCDF")
-        else
-            msdata <- mzR::openMSfile(f)
+        ## issue #214: define backend based on file format.
+        msdata <- mzR::openMSfile(f, backend = mzRBackend(f))
         .instrumentInfo <- c(.instrumentInfo, list(instrumentInfo(msdata)))
         fullhd <- mzR::header(msdata)
         spidx <- seq_len(nrow(fullhd))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1068,19 +1068,39 @@ countAndPrint <- function(x) {
 #' @return A \code{character(1)} with the name of the backend (either
 #'     \code{"netCDF"}, \code{"Ramp"} or \code{"pwiz"}.
 #' 
-#' @author Johannes Rainer
+#' @author Johannes Rainer, Sebastian Gibb
 #'
 #' @noRd
-mzRBackend <- function(x) {
-    backends <- c(pwiz = "\\.mzml($|\\.)|\\.mzxml($|\\.)",
-                  Ramp = "\\.mzdata($|\\.)",
-                  netCDF = "\\.cdf($|\\.)|\\.nc($|\\.)")
-    matches <- sapply(backends, function(z) grep(z, x, ignore.case = TRUE),
-                      simplify = FALSE)
-    backend <- names(matches)[lengths(matches) > 0]
-    if (length(backend))
-        backend
-    else
-        stop("Unknown file type for ", x)
+.mzRBackend <- function(x = character()) {
+    if (length(x) != 1)
+        stop("parameter 'x' has to be of length 1")
+    ## Use if/else conditions based on a suggestion from sgibb to avoid loops.
+    if (grepl("\\.mzml($|\\.)|\\.mzxml($|\\.)", x, ignore.case = TRUE)) {
+        return("pwiz")
+    } else if (grepl("\\.mzdata($|\\.)", x, ignore.case = TRUE)) {
+        return("Ramp")
+    } else if (grepl("\\.cdf($|\\.)|\\.nc($|\\.)", x, ignore.case = TRUE)) {
+        return("netCDF")
+    } else {
+        stop("Could not determine file type for ", x)
+    }
+}
+
+#' @title Open an MS file using the mzR package
+#'
+#' @description Opens an MS file using the mzR package determining the corrent
+#'     backend based on the file ending of the specified file.
+#'
+#' @param x \code{character(1)}: the file name.
+#'
+#' @return A file handle to the opened MS file.
+#'
+#' @author Johannes Rainer
+#' 
+#' @noRd
+.openMSfile <- function(x) {
+    if(missing(x) || length(x) != 1)
+        stop("parameter 'x' has to be of length 1")
+    mzR::openMSfile(x, backend = .mzRBackend(x))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1057,3 +1057,30 @@ countAndPrint <- function(x) {
   if (inherits(object, "OnDiskMSnExp")) msLevel(object)[1]
   else msLevel(object[[1]])
 }
+
+#' @title Define the type of mzR backend to use based on the file name
+#'
+#' @description Simple helper to define the mzR backend that should/can be used
+#'     to read the file.
+#'
+#' @param x \code{character(1)} representing the file name.
+#'
+#' @return A \code{character(1)} with the name of the backend (either
+#'     \code{"netCDF"}, \code{"Ramp"} or \code{"pwiz"}.
+#' 
+#' @author Johannes Rainer
+#'
+#' @noRd
+mzRBackend <- function(x) {
+    backends <- c(pwiz = "\\.mzml($|\\.)|\\.mzxml($|\\.)",
+                  Ramp = "\\.mzdata($|\\.)",
+                  netCDF = "\\.cdf($|\\.)|\\.nc($|\\.)")
+    matches <- sapply(backends, function(z) grep(z, x, ignore.case = TRUE),
+                      simplify = FALSE)
+    backend <- names(matches)[lengths(matches) > 0]
+    if (length(backend))
+        backend
+    else
+        stop("Unknown file type for ", x)
+}
+

--- a/tests/testthat/test_mzR-funs.R
+++ b/tests/testthat/test_mzR-funs.R
@@ -36,7 +36,8 @@ test_that(".chomatogram function", {
     expect_identical(nrow(x), length(ms))
     expect_identical(colnames(x), c("rt", "tic"))
     expect_identical(x$rt, hd$retentionTime)
-    expect_equal(x$tic, 100 * hd$totIonCurrent/ max(hd$totIonCurrent))    
+    expect_equal(x$tic, 100 * hd$totIonCurrent/ max(hd$totIonCurrent))
+    close(ms)
 })
 
 
@@ -44,23 +45,27 @@ test_that("chomatogram methods", {
     f <- dir(system.file("microtofq", package = "msdata"),
              full.names = TRUE, pattern = "MM8.mzML")
     library("mzR")
-    ms <- openMSfile(f)
+    ## Note: this does NOT work yet with backend = "pwiz"!
+    ms <- openMSfile(f, backend = "Ramp")
     ch1 <- chromatogram(f, plot = FALSE)
     ch2 <- chromatogram(ms, plot = FALSE)
     expect_identical(ch1, ch2)
     hd <- header(ms)
     ch3 <- MSnbase:::.chromatogram(hd, plot = FALSE)
     expect_identical(ch1, ch3)
+    close(ms)
 })
 
 test_that("xic", {
     f <- dir(system.file("microtofq", package = "msdata"),
              full.names = TRUE, pattern = "MM8.mzML")
-    ms <- openMSfile(f)
+    ## Note: this does NOT work yet with backend = "pwiz"!
+    ms <- openMSfile(f, backend = "Ramp")
 
     expect_error(xic(ms))
     expect_warning(xicres <- xic(ms, mz = 636.925, width = 0.01, plot = FALSE))
     xicres1 <- xic(ms, mz = 636.925)
     xicres2 <- xic(f, mz = 636.925)
     expect_identical(xicres1, xicres2)
+    close(ms)
 })

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -382,27 +382,53 @@ test_that(".topIdx", {
                c(10, 7, 8, 5, 9, 6))
 })
 
-test_that("mzRBackend works", {
-    res <- MSnbase:::mzRBackend("test.mzml")
+test_that(".mzRBackend works", {
+    res <- MSnbase:::.mzRBackend("test.mzml")
     expect_equal(res, "pwiz")
-    res <- MSnbase:::mzRBackend("test.mzml.gz")
+    res <- MSnbase:::.mzRBackend("test.mzml.gz")
     expect_equal(res, "pwiz")
-    res <- MSnbase:::mzRBackend("test.mzML")
+    res <- MSnbase:::.mzRBackend("test.mzML")
     expect_equal(res, "pwiz")
-    res <- MSnbase:::mzRBackend("test.mzML.bz2")
+    res <- MSnbase:::.mzRBackend("test.mzML.bz2")
     expect_equal(res, "pwiz")
-    res <- MSnbase:::mzRBackend("test.mzXML")
+    res <- MSnbase:::.mzRBackend("test.mzXML")
     expect_equal(res, "pwiz")
 
-    res <- MSnbase:::mzRBackend("test.mzdata")
+    res <- MSnbase:::.mzRBackend("test.mzdata")
     expect_equal(res, "Ramp")
-    res <- MSnbase:::mzRBackend("test.mzdata.gz")
+    res <- MSnbase:::.mzRBackend("test.mzdata.gz")
     expect_equal(res, "Ramp")
     
-    res <- MSnbase:::mzRBackend("test.cdf")
+    res <- MSnbase:::.mzRBackend("test.cdf")
     expect_equal(res, "netCDF")
-    res <- MSnbase:::mzRBackend("test.cdf.gz")
+    res <- MSnbase:::.mzRBackend("test.cdf.gz")
     expect_equal(res, "netCDF")
 
-    expect_error(MSnbase:::mzRBackend("unsupported.txt"))
+    expect_error(MSnbase:::.mzRBackend("unsupported.txt"))
+    expect_error(MSnbase:::.mzRBackend())
+    expect_error(MSnbase:::.mzRBackend(""))
+    expect_error(MSnbase:::.mzRBackend(c("a.mzML", "b.mzML")))
 })
+
+test_that(".openMSfile works", {
+    file <- system.file("microtofq", "MM14.mzML", package = "msdata")
+    res <- MSnbase:::.openMSfile(file)
+    expect_true(is(res, "mzRpwiz"))
+    close(res)
+    file <- system.file("threonine", "threonine_i2_e35_pH_tree.mzXML",
+                        package = "msdata")
+    res <- MSnbase:::.openMSfile(file)
+    expect_true(is(res, "mzRpwiz"))
+    close(res)
+    file <- system.file("microtofq", "MM14.mzdata", package = "msdata")
+    res <- MSnbase:::.openMSfile(file)
+    expect_true(is(res, "mzRramp"))
+    close(res)
+
+    ## Errors
+    expect_error(MSnbase:::.openMSfile(c("a", "b")))
+    file <- c(system.file("microtofq", "MM14.mzML", package = "msdata"),
+              system.file("microtofq", "MM14.mzdata", package = "msdata"))
+    expect_error(MSnbase:::.openMSfile(file))
+})
+

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -381,3 +381,28 @@ test_that(".topIdx", {
   expect_equal(MSnbase:::.topIdx(m, groupBy=g, fun=sum, n=2),
                c(10, 7, 8, 5, 9, 6))
 })
+
+test_that("mzRBackend works", {
+    res <- MSnbase:::mzRBackend("test.mzml")
+    expect_equal(res, "pwiz")
+    res <- MSnbase:::mzRBackend("test.mzml.gz")
+    expect_equal(res, "pwiz")
+    res <- MSnbase:::mzRBackend("test.mzML")
+    expect_equal(res, "pwiz")
+    res <- MSnbase:::mzRBackend("test.mzML.bz2")
+    expect_equal(res, "pwiz")
+    res <- MSnbase:::mzRBackend("test.mzXML")
+    expect_equal(res, "pwiz")
+
+    res <- MSnbase:::mzRBackend("test.mzdata")
+    expect_equal(res, "Ramp")
+    res <- MSnbase:::mzRBackend("test.mzdata.gz")
+    expect_equal(res, "Ramp")
+    
+    res <- MSnbase:::mzRBackend("test.cdf")
+    expect_equal(res, "netCDF")
+    res <- MSnbase:::mzRBackend("test.cdf.gz")
+    expect_equal(res, "netCDF")
+
+    expect_error(MSnbase:::mzRBackend("unsupported.txt"))
+})


### PR DESCRIPTION
- Fix for issue #214: switch mzR backend based on the file type.
- Add unit tests for the new mzRBackend function.
- Fix unit tests in test_mzR-funs.R failing after switch to the new backend.