### PR TITLE
Fix issue #215

### DIFF
--- a/R/functions-Spectrum1.R
+++ b/R/functions-Spectrum1.R
@@ -93,12 +93,15 @@ Spectra1_mz_sorted <- function(peaksCount = NULL, rt = numeric(),
                                intensity = numeric(), fromFile = integer(),
                                centroided = NA, smoothed = NA,
                                polarity = NA_integer_, nvalues = integer()) {
-    if (length(mz) == 0 | length(intensity) == 0 | length(nvalues) == 0) {
-        stop("Arguments 'mz', 'intensity' and 'nvalues' are required!")
-    } else {
-        if (length(mz) != length(intensity))
-            stop("Lengths of 'mz' and 'intensity' do not match!")
-    }
+    ## Fix issue #215: remove check to allow empty spectra
+    ## if (length(mz) == 0 | length(intensity) == 0 | length(nvalues) == 0) {
+    ##     stop("Arguments 'mz', 'intensity' and 'nvalues' are required!")
+    ## }
+    if (sum(nvalues) != length(mz))
+        stop("Length of 'mz' does not match with the number of values per ",
+             "spectrum")
+    if (length(mz) != length(intensity))
+        stop("Lengths of 'mz' and 'intensity' do not match!")
     nvals <- length(nvalues)
     ## Now match all of the lengths to the length of nvalues.
     if (length(peaksCount) == 0)

--- a/R/functions-Spectrum2.R
+++ b/R/functions-Spectrum2.R
@@ -94,12 +94,15 @@ Spectra2_mz_sorted <- function(peaksCount = NULL, rt = numeric(),
                                precursorCharge = NA_integer_,
                                collisionEnergy = NA, nvalues = integer()) {
     ## Argument check; make sure all is OK before calling C.
-    if (length(mz) == 0 | length(intensity) == 0 | length(nvalues) == 0) {
-        stop("Arguments 'mz', 'intensity' and 'nvalues' are required!")
-    } else {
-        if (length(mz) != length(intensity))
-            stop("Lengths of 'mz' and 'intensity' do not match!")
-    }
+    ## Fix issue #215: remove check to allow empty spectra
+    ## if (length(mz) == 0 | length(intensity) == 0 | length(nvalues) == 0) {
+    ##     stop("Arguments 'mz', 'intensity' and 'nvalues' are required!")
+    ## }
+    if (sum(nvalues) != length(mz))
+        stop("Length of 'mz' does not match with the number of values per ",
+             "spectrum")
+    if (length(mz) != length(intensity))
+        stop("Lengths of 'mz' and 'intensity' do not match!")
     nvals <- length(nvalues)
     ## Now match all of the lengths to the length of nvalues.
     if (length(peaksCount) == 0)

--- a/tests/testthat/test_Spectrum_Constructor.R
+++ b/tests/testthat/test_Spectrum_Constructor.R
@@ -25,7 +25,8 @@ test_that("Spectrum1 constructor", {
     expect_identical(classVersion(Res1)["Spectrum"],
                      new("Versions",
                          Spectrum = MSnbase:::getClassVersionString("Spectrum")))
-
+    ## Check empty spectrum
+    expect_true(validObject(MSnbase:::Spectrum1()))
 })
 
 test_that("M/Z sorted Spectrum1 constructor", {
@@ -58,7 +59,8 @@ test_that("M/Z sorted Spectrum1 constructor", {
     expect_identical(classVersion(sp3)["Spectrum"],
                      new("Versions",
                          Spectrum = MSnbase:::getClassVersionString("Spectrum")))
-
+    ## Check empty spectrum
+    expect_true(validObject(MSnbase:::Spectrum1_mz_sorted()))
 })
 
 ## Test the c-level multi-Spectrum1 constructor with M/Z ordering.
@@ -141,7 +143,8 @@ test_that("C-level multi-Spectrum1 constructor with M/Z ordering", {
     expect_equal(length(mz(res[[2]])), 0)
     expect_equal(length(mz(res[[4]])), 20)
     expect_equal(mz(res[[4]]), mzVals[51:70])
-
+    expect_true(all(unlist(lapply(res, validObject))))
+    
     ## If nVals does NOT match mz
     nVals_err <- c(50, 0, 0, 20, 0, 100, 0, 30, 4)
     expect_error(MSnbase:::Spectra1_mz_sorted(rt = rts,
@@ -149,23 +152,6 @@ test_that("C-level multi-Spectrum1 constructor with M/Z ordering", {
                                               mz = mzVals, intensity = intVals,
                                               nvalues = nVals_err))
     
-    ## Spectrum2
-    mzVals <- sort(abs(rnorm(200, mean = 100, sd = 10)))
-    intVals <- abs(rnorm(200, mean = 10, sd = 5))
-    nVals <- c(50, 0, 0, 20, 0, 100, 0, 30, 0)
-    rts <- c(1, 2, 3, 4, 5, 6, 7, 8, 9)
-    res <- MSnbase:::Spectra2_mz_sorted(rt = rts,
-                                        acquisitionNum = 1:length(nVals),
-                                        mz = mzVals, intensity = intVals,
-                                        nvalues = nVals)
-    expect_equal(length(res), length(nVals))
-    expect_equal(length(mz(res[[2]])), 0)
-    expect_equal(length(mz(res[[4]])), 20)
-    expect_equal(mz(res[[4]]), mzVals[51:70])
-    expect_error(MSnbase:::Spectra2_mz_sorted(rt = rts,
-                                              acquisitionNum = 1:length(nVals),
-                                              mz = mzVals, intensity = intVals,
-                                              nvalues = nVals_err))
 })
 
 
@@ -219,6 +205,10 @@ test_that("M/Z sorted Spectrum2 constructor", {
     ## o Pass only intensity or mz
     expect_error(new("Spectrum2", intensity = intVals, polarity = 1L))
     expect_error(new("Spectrum2", mz = muVals, polarity = 1L))
+
+    ## Check empty spectrum
+    expect_true(validObject(MSnbase:::Spectrum2()))
+    expect_true(validObject(MSnbase:::Spectrum2_mz_sorted()))
 })
 
 ## Test the c-level multi-Spectrum2 constructor with M/Z ordering.
@@ -286,4 +276,22 @@ test_that("C-level multi-Spectrum2 constructor with M/Z ordering", {
         expect_identical(mz(spectL[[i]]), mzValsList[[i]][idxList[[i]]])
         expect_identical(intensity(spectL[[i]]), intValsList[[i]][idxList[[i]]])
     }
+
+    ## Spectrum2
+    mzVals <- sort(abs(rnorm(200, mean = 100, sd = 10)))
+    intVals <- abs(rnorm(200, mean = 10, sd = 5))
+    nVals <- c(50, 0, 0, 20, 0, 100, 0, 30, 0)
+    rts <- c(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    res <- MSnbase:::Spectra2_mz_sorted(rt = rts,
+                                        acquisitionNum = 1:length(nVals),
+                                        mz = mzVals, intensity = intVals,
+                                        nvalues = nVals)
+    expect_equal(length(res), length(nVals))
+    expect_equal(length(mz(res[[2]])), 0)
+    expect_equal(length(mz(res[[4]])), 20)
+    expect_equal(mz(res[[4]]), mzVals[51:70])
+    expect_error(MSnbase:::Spectra2_mz_sorted(rt = rts,
+                                              acquisitionNum = 1:length(nVals),
+                                              mz = mzVals, intensity = intVals,
+                                              nvalues = nVals_err))
 })

--- a/tests/testthat/test_Spectrum_Constructor.R
+++ b/tests/testthat/test_Spectrum_Constructor.R
@@ -126,6 +126,46 @@ test_that("C-level multi-Spectrum1 constructor with M/Z ordering", {
         expect_identical(mz(spectL[[i]]), mzValsList[[i]][idxList[[i]]])
         expect_identical(intensity(spectL[[i]]), intValsList[[i]][idxList[[i]]])
     }
+
+    ## Check empty spectra.
+    ## Spectrum1
+    mzVals <- sort(abs(rnorm(200, mean = 100, sd = 10)))
+    intVals <- abs(rnorm(200, mean = 10, sd = 5))
+    nVals <- c(50, 0, 0, 20, 0, 100, 0, 30, 0)
+    rts <- c(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    res <- MSnbase:::Spectra1_mz_sorted(rt = rts,
+                                        acquisitionNum = 1:length(nVals),
+                                        mz = mzVals, intensity = intVals,
+                                        nvalues = nVals)
+    expect_equal(length(res), length(nVals))
+    expect_equal(length(mz(res[[2]])), 0)
+    expect_equal(length(mz(res[[4]])), 20)
+    expect_equal(mz(res[[4]]), mzVals[51:70])
+
+    ## If nVals does NOT match mz
+    nVals_err <- c(50, 0, 0, 20, 0, 100, 0, 30, 4)
+    expect_error(MSnbase:::Spectra1_mz_sorted(rt = rts,
+                                              acquisitionNum = 1:length(nVals),
+                                              mz = mzVals, intensity = intVals,
+                                              nvalues = nVals_err))
+    
+    ## Spectrum2
+    mzVals <- sort(abs(rnorm(200, mean = 100, sd = 10)))
+    intVals <- abs(rnorm(200, mean = 10, sd = 5))
+    nVals <- c(50, 0, 0, 20, 0, 100, 0, 30, 0)
+    rts <- c(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    res <- MSnbase:::Spectra2_mz_sorted(rt = rts,
+                                        acquisitionNum = 1:length(nVals),
+                                        mz = mzVals, intensity = intVals,
+                                        nvalues = nVals)
+    expect_equal(length(res), length(nVals))
+    expect_equal(length(mz(res[[2]])), 0)
+    expect_equal(length(mz(res[[4]])), 20)
+    expect_equal(mz(res[[4]]), mzVals[51:70])
+    expect_error(MSnbase:::Spectra2_mz_sorted(rt = rts,
+                                              acquisitionNum = 1:length(nVals),
+                                              mz = mzVals, intensity = intVals,
+                                              nvalues = nVals_err))
 })
 
 

--- a/tests/testthat/test_Spectrum_Constructor.R
+++ b/tests/testthat/test_Spectrum_Constructor.R
@@ -30,6 +30,7 @@ test_that("Spectrum1 constructor", {
 })
 
 test_that("M/Z sorted Spectrum1 constructor", {
+    set.seed(123)
     mzVals <- abs(rnorm(3500, mean = 100, sd = 10))
     intVals <- abs(rnorm(3500, mean = 10, sd = 5))
 
@@ -69,6 +70,7 @@ test_that("M/Z sorted Spectrum1 constructor", {
 ## o Check that classVersions are properly set.
 test_that("C-level multi-Spectrum1 constructor with M/Z ordering", {
     ## Use Spectra1_mz_sorted constructor.
+    set.seed(123)
     mzVals <- abs(rnorm(20000, mean = 10, sd = 10))
     intVals <- abs(rnorm(20000, mean = 1000, sd = 1000))
     rts <- c(1.3, 1.4, 1.5, 1.6)
@@ -160,6 +162,7 @@ test_that("C-level multi-Spectrum1 constructor with M/Z ordering", {
 
 ## M/Z sorted Spectrum2 constructor.
 test_that("M/Z sorted Spectrum2 constructor", {
+    set.seed(123)
     mzVals <- abs(rnorm(3500, mean = 100, sd = 10))
     intVals <- abs(rnorm(3500, mean = 10, sd = 5))
 
@@ -216,6 +219,7 @@ test_that("M/Z sorted Spectrum2 constructor", {
 ## o Check that the Spectrum values are as expected.
 test_that("C-level multi-Spectrum2 constructor with M/Z ordering", {
     ## Use Spectra2_mz_sorted constructor.
+    set.seed(123)
     mzVals <- abs(rnorm(20000, mean = 10, sd = 10))
     intVals <- abs(rnorm(20000, mean = 1000, sd = 1000))
     rts <- c(1.3, 1.4, 1.5, 1.6)


### PR DESCRIPTION
- Remove check for parameters being of length > 0.
- Add unit tests to ensure empty spectra are correctly returned.