### PR TITLE
Remove redundant readMSData and readMSData2 calls from unit tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,4 +7,27 @@ library("MSnbase")
 setMSnbaseVerbose(FALSE)
 register(SerialParam()) ## see issue 205
 
+## Erwinia
+f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
+tmt_erwinia_in_mem_ms1 <- readMSData(f, msLevel = 1)
+tmt_erwinia_in_mem_ms2 <- readMSData(f, msLevel = 2)
+tmt_erwinia_on_disk <- readMSData2(f)
+tmt_erwinia_on_disk_ms1 <- readMSData2(f, msLevel = 1)
+tmt_erwinia_on_disk_ms2 <- readMSData2(f, msLevel = 2)
+
+## microtofq
+f <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
+       system.file("microtofq/MM8.mzML", package = "msdata"))
+microtofq_in_mem_ms1 <- readMSData(f, msLevel = 1)
+microtofq_on_disk_ms1 <- readMSData2(f, msLevel = 1)
+microtofq_on_disk <- readMSData2(f)
+
+## extdata mzML
+f <- dir(system.file(package = "MSnbase", dir = "extdata"),
+         full.name = TRUE, pattern = "mzXML$")
+extdata_mzXML_in_mem_ms2 <- readMSData(f, verbose = FALSE, centroided. = FALSE)
+extdata_mzXML_on_disk <- readMSData2(f, centroided. = FALSE)
+extdata_mzXML_on_disk_ms2 <- readMSData2(f, msLevel = 2, centroided. = FALSE)
+
+
 test_check("MSnbase")

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -151,10 +151,7 @@ context("MSnExp processing")
 context("MSnExp data")
 
 test_that("spectra order and integrity", {
-    file <- dir(system.file(package = "MSnbase", dir = "extdata"),
-                full.name = TRUE,
-                pattern = "mzXML$")
-    aa <- readMSData(file, verbose = FALSE, centroided. = FALSE)
+    aa <- extdata_mzXML_in_mem_ms2
     clean.aa <- clean(aa, verbose = FALSE)
     rmpeaks.aa <- removePeaks(aa, verbose = FALSE)
     expect_equal(ls(assayData(clean.aa)), ls(assayData(aa)))
@@ -198,7 +195,7 @@ test_that("addIdentificationData", {
                                        identFile, verbose = FALSE),
                  "No feature data found.")
 
-    aa <- readMSData(quantFile, verbose = FALSE)
+    aa <- extdata_mzXML_in_mem_ms2
 
     expect_error(addIdentificationData(aa, "foobar.mzid",
                                        verbose = FALSE),
@@ -227,8 +224,8 @@ test_that("addIdentificationData to OnDiskMSnExp", {
                      full.name = TRUE, pattern = "mzXML$")
     identFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                      full.name = TRUE, pattern = "dummyiTRAQ.mzid")
-    rw1 <- readMSData(quantFile)
-    rw2 <- readMSData2(quantFile)
+    rw1 <- extdata_mzXML_in_mem_ms2
+    rw2 <- extdata_mzXML_on_disk_ms2
     expect_true(all.equal(rw1, rw2))
     rw1 <- addIdentificationData(rw1, identFile)
     rw2 <- addIdentificationData(rw2, identFile)
@@ -250,12 +247,10 @@ test_that("addIdentificationData to OnDiskMSnExp", {
 
 
 test_that("idSummary", {
-    quantFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
-                     full.name = TRUE, pattern = "mzXML$")
     identFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                      full.name = TRUE, pattern = "dummyiTRAQ.mzid")
 
-    aa <- readMSData(quantFile, verbose = FALSE)
+    aa <- extdata_mzXML_in_mem_ms2
     bb <- addIdentificationData(aa, identFile, verbose = FALSE)
 
     expect_error(idSummary(aa), "No quantification/identification data found")
@@ -328,18 +323,16 @@ test_that("Noise estimation MSnExp", {
 test_that("isolation window", {
     f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
     i1 <- isolationWindow(f, unique = FALSE)
-    i2 <- isolationWindow(readMSData2(f), unique = FALSE)
-    i3 <- isolationWindow(readMSData(f), unique = FALSE)
+    i2 <- isolationWindow(tmt_erwinia_on_disk, unique = FALSE)
+    i3 <- isolationWindow(tmt_erwinia_in_mem_ms2, unique = FALSE)
     expect_identical(i1, i2)
     expect_identical(i1, i3)
 })
 
 test_that("spectrapply,MSnExp", {
     library(msdata)
-    mzf <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
-             system.file("microtofq/MM8.mzML", package = "msdata"))
-    inMem <- readMSData(files = mzf, msLevel. = 1, centroided. = TRUE)
-
+    inMem <- microtofq_in_mem_ms1
+    
     sps <- spectra(inMem)
     sps_2 <- spectrapply(inMem)
     expect_identical(sps, sps_2)
@@ -351,9 +344,7 @@ test_that("spectrapply,MSnExp", {
 
 test_that("splitByFile,MSnExp", {
     library(msdata)
-    mzf <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
-             system.file("microtofq/MM8.mzML", package = "msdata"))
-    inMem <- readMSData(files = mzf, msLevel. = 1, centroided. = TRUE)
+    inMem <- microtofq_in_mem_ms1
     expect_error(splitByFile(inMem, f = factor(1:3)))
     spl <- splitByFile(inMem, f = factor(c("b", "a")))
     expect_equal(spectra(spl[[1]]), spectra(filterFile(inMem, 2)))

--- a/tests/testthat/test_MSnExpFilters.R
+++ b/tests/testthat/test_MSnExpFilters.R
@@ -1,11 +1,10 @@
 context("MSnExp filter functions")
 
-f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia_1")
-inmem2 <- readMSData(f, centroided = NA, verbose = FALSE)  ## That's the MS 2 data.
-inmem1 <- readMSData(f, centroided = NA, verbose = FALSE, msLevel = 1)  ## MS 1 data.
-ondisk <- readMSData2(f, verbose = FALSE)
-ondisk1 <- readMSData2(f, msLevel = 1, verbose = FALSE)
-ondisk2 <- readMSData2(f, msLevel = 2, verbose = FALSE)
+inmem1 <- tmt_erwinia_in_mem_ms1
+inmem2 <- tmt_erwinia_in_mem_ms2
+ondisk <- tmt_erwinia_on_disk
+ondisk1 <- tmt_erwinia_on_disk_ms1
+ondisk2 <- tmt_erwinia_on_disk_ms2
 
 test_that("filterMsLevel", {
     expect_true(all.equal(inmem2, filterMsLevel(inmem2, msLevel. = 2)))
@@ -39,14 +38,10 @@ test_that("filterFile", {
     ## Use two files.
     mzfiles <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
                  system.file("microtofq/MM8.mzML", package = "msdata"))
-    oneFileInMem <- readMSData(mzfiles[2], verbose = FALSE, msLevel = 1,
-                               centroided = TRUE)
-    twoFileInMem <- readMSData(mzfiles, verbose = FALSE, msLevel = 1,
-                               centroided = TRUE)
-    twoFileOnDisk <- readMSData2(mzfiles, verbose = FALSE,
-                                 centroided = TRUE)
-    secondFileOnDisk <- readMSData2(mzfiles[2], verbose = FALSE,
-                                    centroided = TRUE)
+    oneFileInMem <- readMSData(mzfiles[2], verbose = FALSE, msLevel = 1)
+    twoFileInMem <- microtofq_in_mem_ms1
+    twoFileOnDisk <- microtofq_on_disk
+    secondFileOnDisk <- readMSData2(mzfiles[2], verbose = FALSE)
     ## Note: all.equal MSnExp, MSnExp will fail because of the
     ## experimentData and featureNames
     expect_true(all.equal(spectra(filterFile(twoFileInMem, file = 2)),
@@ -85,7 +80,8 @@ test_that("filterAcquisitionNum", {
     ## Torture tests. The two files have different number of spectra.
     mzfiles <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
                  system.file("microtofq/MM8.mzML", package = "msdata"))
-    twoFileOnDisk <- readMSData2(mzfiles, centroided. = TRUE)
+    twoFileOnDisk <- microtofq_on_disk
+    centroided(twoFileOnDisk) <- TRUE
     secondFile <- readMSData2(mzfiles[2], verbose = FALSE, centroided = TRUE)
     expect_warning(res <- filterAcquisitionNum(twoFileOnDisk, n = 180:190, file = 1))
     expect_identical(fileNames(res), fileNames(twoFileOnDisk)[2])
@@ -138,8 +134,7 @@ test_that("filterMz", {
     ## On multiple files.
     mzfiles <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
                  system.file("microtofq/MM8.mzML", package = "msdata"))
-    twoFileOnDisk <- readMSData2(mzfiles, verbose = FALSE,
-                                 centroided = TRUE)
+    twoFileOnDisk <- microtofq_on_disk
     twoFileOnDiskF <- filterMz(twoFileOnDisk, mz = c(300, 350))
     mzr <- range(mz(twoFileOnDiskF))
     expect_true(mzr[1] >= 300 & mzr[2] <= 350)

--- a/tests/testthat/test_MSnSet.R
+++ b/tests/testthat/test_MSnSet.R
@@ -280,7 +280,7 @@ test_that("addIdentificationData", {
   identFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                    full.name = TRUE, pattern = "dummyiTRAQ.mzid")
 
-  aa <- readMSData(quantFile, verbose = FALSE, centroided. = FALSE)
+  aa <- extdata_mzXML_in_mem_ms2
   msnset <- quantify(aa, method = "trap", reporters = iTRAQ4,
                      BPPARAM = SerialParam(),
                      verbose = FALSE)
@@ -308,7 +308,8 @@ test_that("idSummary", {
                    full.name = TRUE, pattern = "mzXML$")
   identFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                    full.name = TRUE, pattern = "dummyiTRAQ.mzid")
-  aa <- readMSData(quantFile, centroided. = FALSE)
+  ## aa <- readMSData(quantFile, centroided. = FALSE)
+  aa <- extdata_mzXML_in_mem_ms2
   msnset <- quantify(aa, method = "trap", reporters = iTRAQ4,
                      BPPARAM = SerialParam())
   bb <- addIdentificationData(msnset, identFile)

--- a/tests/testthat/test_OnDiskMSnExp.R
+++ b/tests/testthat/test_OnDiskMSnExp.R
@@ -1,15 +1,15 @@
 context("OnDiskMSnExp class")
 
-library(msdata)
-mzf <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
-         system.file("microtofq/MM8.mzML", package = "msdata"))
-inMem <- readMSData(files = mzf, msLevel. = 1, centroided. = TRUE)
-onDisk <- readMSData2(files = mzf, msLevel. = 1, centroided. = TRUE)
-
-f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
-multiMsInMem1 <- readMSData(files = f, msLevel. = 1, centroided. = TRUE)
-multiMsInMem2 <- readMSData(files = f, msLevel. = 2, centroided. = TRUE)
-multiMsOnDisk <- readMSData2(files = f, centroided. = TRUE)
+inMem <- microtofq_in_mem_ms1
+onDisk <- microtofq_on_disk_ms1
+multiMsInMem1 <- tmt_erwinia_in_mem_ms1
+multiMsInMem2 <- tmt_erwinia_in_mem_ms2
+multiMsOnDisk <- tmt_erwinia_on_disk
+centroided(inMem) <- TRUE
+centroided(onDisk) <- TRUE
+centroided(multiMsInMem1) <- TRUE
+centroided(multiMsInMem2) <- TRUE
+centroided(multiMsOnDisk) <- TRUE
 
 ############################################################
 ## validateOnDiskMSnExp
@@ -45,9 +45,8 @@ test_that("OnDiskMSnExp constructor", {
 })
 
 test_that("Coercion to MSnExp", {
-    f <- msdata:::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
-    x <- readMSData2(f, verbose = FALSE)
-    y <- readMSData(f, msLevel. = 2, centroided. = NA, verbose = FALSE)
+    x <- tmt_erwinia_on_disk
+    y <- tmt_erwinia_in_mem_ms2
     expect_error(as(x, "MSnExp"))
     x <- filterMsLevel(x, msLevel = 2)
     expect_true(all.equal(x, y))
@@ -293,10 +292,7 @@ test_that("spectrapply,OnDiskMSnExp", {
 })
 
 test_that("splitByFile,OnDiskMSnExp", {
-    library(msdata)
-    mzf <- c(system.file("microtofq/MM14.mzML", package = "msdata"),
-             system.file("microtofq/MM8.mzML", package = "msdata"))
-    od <- readMSData2(files = mzf, msLevel. = 1, centroided. = TRUE)
+    od <- microtofq_on_disk_ms1
     expect_error(splitByFile(od, f = factor(1:3)))
     spl <- splitByFile(od, f = factor(c("b", "a")))
     expect_equal(pData(spl[[1]]), pData(filterFile(od, 2)))

--- a/tests/testthat/test_OnDiskMSnExp2.R
+++ b/tests/testthat/test_OnDiskMSnExp2.R
@@ -3,16 +3,16 @@ context("OnDiskMSnExp class")
 f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
 
 test_that("OnDiskMSnExp constructor", {
-    x <- readMSData2(f)
+    x <- tmt_erwinia_on_disk
     expect_true(validObject(x))
     expect_true(all(unique(msLevel(x)) == 1:2))
     expect_true(all(isCurrent(x)))
     expect_true(isVersioned(x))
     expect_null(show(x))
-    x1 <- readMSData2(f, msLevel = 1)
+    x1 <- tmt_erwinia_on_disk_ms1
     expect_true(validObject(x1))
     expect_true(unique(msLevel(x1)) == 1)
-    x2 <- readMSData2(f, msLevel = 2)
+    x2 <- tmt_erwinia_on_disk_ms2
     expect_true(validObject(x2))
     expect_true(unique(msLevel(x2)) == 2)
     expect_identical(length(x), length(x1) + length(x2))
@@ -23,8 +23,10 @@ test_that("OnDiskMSnExp constructor", {
 })
 
 test_that("compare MS2 on disk and in memory", {
-    x1 <- readMSData(f, verbose = FALSE, centroided. = FALSE)
-    x2 <- readMSData2(f, msLevel. = 2, centroided. = FALSE)
+    x1 <- tmt_erwinia_in_mem_ms2
+    x2 <- tmt_erwinia_on_disk_ms2
+    centroided(x1) <- FALSE
+    centroided(x2) <- FALSE
     expect_identical(length(x1), length(x2))
     expect_false(identical(featureNames(x1), featureNames(x2)))
     featureNames(x2) <- featureNames(x1)
@@ -92,8 +94,8 @@ test_that("Default and setting centroided", {
 })
 
 test_that("Write mgf", {
-    x1 <- readMSData(f, verbose = FALSE)
-    x2 <- readMSData2(f, msLevel. = 2)
+    x1 <- tmt_erwinia_in_mem_ms2
+    x2 <- tmt_erwinia_on_disk_ms2
     tf1 <- tempfile()
     tf2 <- tempfile()
     writeMgfData(x1[2:4], con = tf1)
@@ -108,13 +110,11 @@ test_that("Write mgf", {
 })
 
 test_that("Adding identification data", {
-    quantFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
-                     full.name = TRUE, pattern = "mzXML$")
     identFile <- dir(system.file(package = "MSnbase", dir = "extdata"),
                      full.name = TRUE, pattern = "dummyiTRAQ.mzid")
-    x1 <- readMSData(quantFile, verbose = FALSE)
+    x1 <- extdata_mzXML_in_mem_ms2
     x1 <- addIdentificationData(x1, identFile, verbose = FALSE)
-    x2 <- readMSData2(quantFile, verbose = FALSE)
+    x2 <- extdata_mzXML_on_disk_ms2
     x2 <- addIdentificationData(x2, identFile, verbose = FALSE)
     fv <- intersect(fvarLabels(x1), fvarLabels(x2))
     expect_identical(fData(x1)[, fv], fData(x2)[, fv])
@@ -141,11 +141,11 @@ test_that("Spectrum processing", {
 })
 
 test_that("removeReporters,OnDiskMSnExp", {
-    in_mem <- readMSData(f, msLevel. = 2)
+    in_mem <- tmt_erwinia_in_mem_ms2
     in_mem_rem <- removeReporters(in_mem, TMT6)
 
-    on_disk <- readMSData2(f)
-    on_disk_2 <- filterMsLevel(on_disk, msLevel. = 2)
+    on_disk <- tmt_erwinia_on_disk
+    on_disk_2 <- tmt_erwinia_on_disk_ms2
     on_disk_2_rem <- removeReporters(on_disk_2, TMT6)
     sp_rem <- spectra(on_disk_2_rem)
     expect_identical(unname(spectra(in_mem_rem)), unname(sp_rem))

--- a/tests/testthat/test_OnDiskMSnExp_other_methods.R
+++ b/tests/testthat/test_OnDiskMSnExp_other_methods.R
@@ -1,20 +1,15 @@
 context("OnDiskMSnExp class, other methods")
 
-library("msdata")
-mzf <-  c(system.file("microtofq/MM14.mzML", package = "msdata"),
-          system.file("microtofq/MM8.mzML", package = "msdata"))
+inMem <- microtofq_in_mem_ms1
+onDisk <- microtofq_on_disk_ms1
+centroided(inMem) <- TRUE
+centroided(onDisk) <- TRUE
 
-inMem <- readMSData(files = mzf, msLevel. = 1, centroided. = TRUE,
-                    verbose = FALSE)
-onDisk <- readMSData2(files = mzf, msLevel. = 1, centroided. = TRUE,
-                      verbose = FALSE)
-
-f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia_1")
-inmem2 <- readMSData(f, centroided. = NA, verbose = FALSE)  ## That's the MS 2 data.
-inmem1 <- readMSData(f, centroided. = NA, verbose = FALSE, msLevel = 1)  ## MS 1 data.
-ondisk <- readMSData2(f, verbose = FALSE)
-ondisk1 <- readMSData2(f, msLevel. = 1, verbose = FALSE)
-ondisk2 <- readMSData2(f, msLevel. = 2, verbose = FALSE)
+inmem2 <- tmt_erwinia_in_mem_ms2
+inmem1 <- tmt_erwinia_in_mem_ms1
+ondisk <- tmt_erwinia_on_disk
+ondisk1 <- tmt_erwinia_on_disk_ms1
+ondisk2 <- tmt_erwinia_on_disk_ms2
 
 
 ############################################################

--- a/tests/testthat/test_centroided.R
+++ b/tests/testthat/test_centroided.R
@@ -1,7 +1,6 @@
 test_that("centroided accessor with/without na.fail", {
-    f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia")
-    x <- readMSData(f)
-    x2 <- readMSData2(f)
+    x <- tmt_erwinia_in_mem_ms2
+    x2 <- tmt_erwinia_on_disk
     ## in-mem, single spectrum
     expect_true(is.na(centroided(x[[1]])))
     expect_error(centroided(x[[1]], na.fail = TRUE))

--- a/tests/testthat/test_equalMSnExps.R
+++ b/tests/testthat/test_equalMSnExps.R
@@ -1,22 +1,16 @@
 context("[OnDisk]MSnExp equality")
 
-f <- msdata::proteomics(full.names = TRUE, pattern = "TMT_Erwinia_1")
-## Set centroided to NA to fit with default behaviour of readMSData2
-inmem1 <- readMSData(f, msLevel = 1, verbose = FALSE, centroided = NA)
-inmem2 <- readMSData(f, msLevel = 2, verbose = FALSE, centroided = NA)
-ondisk <- readMSData2(f, verbose = FALSE)
-ondisk1 <- readMSData2(f, msLevel = 1, verbose = FALSE)
-ondisk2 <- readMSData2(f, msLevel = 2, verbose = FALSE)
-
 test_that("Equality function", {
     ## testing it on spectra only.
-    expect_true(all.equal(inmem1, ondisk1))
-    expect_true(all.equal(inmem2, ondisk2))
+    expect_true(all.equal(tmt_erwinia_in_mem_ms1, tmt_erwinia_on_disk_ms1))
+    expect_true(all.equal(tmt_erwinia_in_mem_ms2, tmt_erwinia_on_disk_ms2))
     ## postive controls
-    expect_true(all.equal(inmem1, inmem1))
-    expect_true(all.equal(inmem2, inmem2))
-    expect_true(all.equal(ondisk, ondisk))
+    expect_true(all.equal(tmt_erwinia_in_mem_ms1, tmt_erwinia_in_mem_ms1))
+    expect_true(all.equal(tmt_erwinia_in_mem_ms2, tmt_erwinia_in_mem_ms2))
+    expect_true(all.equal(tmt_erwinia_on_disk_ms1, tmt_erwinia_on_disk_ms1))
     ## negative controls
-    expect_false(isTRUE(all.equal(ondisk, ondisk1)))
-    expect_false(isTRUE(all.equal(ondisk, ondisk2)))
+    expect_false(isTRUE(all.equal(tmt_erwinia_in_mem_ms1,
+                                  tmt_erwinia_in_mem_ms2)))
+    expect_false(isTRUE(all.equal(tmt_erwinia_on_disk_ms1,
+                                  tmt_erwinia_on_disk_ms2)))
 })

--- a/tests/testthat/test_filterEmptySpectra.R
+++ b/tests/testthat/test_filterEmptySpectra.R
@@ -1,15 +1,12 @@
 test_that("filterEmptySpectra", {
-    require("msdata")
-    mzf <- system.file("microtofq/MM14.mzML", package = "msdata")
-    
     ## ondisk
-    od <- readMSData2(files = mzf, msLevel. = 1, centroided. = TRUE)
+    od <- filterFile(microtofq_on_disk_ms1, file = 1)
     od2 <- filterMz(od, mz = c(1005, 1006))
     expect_identical(length(od), length(od2))
     expect_identical(length(filterEmptySpectra(od2)), 0L)
     
     ## inmem
-    im <- readMSData(files = mzf, msLevel. = 1, centroided. = TRUE)
+    im <- filterFile(microtofq_in_mem_ms1, file = 1)
     im2 <- filterMz(im, mz = c(1005, 1006))
     expect_identical(length(im), length(im2))
     expect_identical(length(filterEmptySpectra(im2)), 0L)

--- a/tests/testthat/test_purity.R
+++ b/tests/testthat/test_purity.R
@@ -1,9 +1,7 @@
 context("Purity correction")
 
 test_that("Purity correction identify", {
-    file <- dir(system.file(package = "MSnbase", dir = "extdata"),
-                full.name = TRUE, pattern = "mzXML$")
-    aa <- readMSData(file, centroided = FALSE)
+    aa <- extdata_mzXML_in_mem_ms2
     bp <- SerialParam()
     msnset <- quantify(aa, method = "trap", reporters = iTRAQ4,
                        BPPARAM = bp)

--- a/tests/testthat/test_quant.R
+++ b/tests/testthat/test_quant.R
@@ -105,10 +105,8 @@ test_that("MS2 labelfree quantitation: SAF", {
 
 
 test_that("quantify_OnDiskMSnExp_max (fastquant_max)", {
-    f <- dir(system.file(package = "MSnbase",dir = "extdata"),
-             full.name = TRUE, pattern = "dummyiTRAQ.mzXML")
-    x1 <- readMSData(f, msLevel = 2, verbose = FALSE)
-    x2 <- readMSData2(f, msLevel = 2, verbose = FALSE)
+    x1 <- extdata_mzXML_in_mem_ms2
+    x2 <- extdata_mzXML_on_disk_ms2
     e1 <- quantify(x1, method = "max", reporters = iTRAQ4, verbose = FALSE)
     e2 <- quantify(x2, method = "max", reporters = iTRAQ4, verbose = FALSE)
     expect_identical(exprs(e1), exprs(e2))


### PR DESCRIPTION
Read common test files only once. Should reduce unit test running time a bit.