### PR TITLE
Add msLevel slot to Chromatogram class

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 Changes in version 2.3.10
 -------------------------
 - New isCentroidedFromFile function <2017-08-11 Fri>
+- Add msLevel slot to Chromatogram object <2017-08-16 Wed>
+- Add msLevel argument to chromatogram,MSnExp method <2017-08-16 Wed>
 
 Changes in version 2.3.9
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Changes in version 2.3.10
 - New isCentroidedFromFile function <2017-08-11 Fri>
+- Add msLevel slot to Chromatogram object <2017-08-16 Wed>
+- Add msLevel argument to chromatogram,MSnExp method <2017-08-16 Wed>
 
 ## Changes in version 2.3.9
 - Using new mzR::openIdfile backend to add identifcation data to raw

--- a/R/DataClasses.R
+++ b/R/DataClasses.R
@@ -558,7 +558,8 @@ setClass("Chromatogram",
              precursorMz = "numeric", ## Or call that Q1mz?
              productMz = "numeric",   ## Or call that Q3mz?
              fromFile = "integer",
-             aggregationFun = "character"
+             aggregationFun = "character",
+             msLevel = "integer"
          ),
          contains = "Versioned",
          prototype = prototype(
@@ -569,7 +570,8 @@ setClass("Chromatogram",
              precursorMz = c(NA_real_, NA_real_),
              productMz = c(NA_real_, NA_real_),
              fromFile = integer(),
-             aggregationFun = character()
+             aggregationFun = character(),
+             msLevel = 1L
          ),
          validity = function(object)
              .validChromatogram(object)

--- a/R/functions-Chromatogram.R
+++ b/R/functions-Chromatogram.R
@@ -115,7 +115,7 @@ Chromatogram <- function(rtime = numeric(), intensity = numeric(),
         mz = range(mz), filterMz = range(filterMz),
         precursorMz = range(precursorMz), productMz = range(productMz),
         fromFile = as.integer(fromFile), aggregationFun = aggregationFun,
-        msLevel = msLevel)
+        msLevel = as.integer(msLevel))
 }
 
 #' @description Plot a single Chromatogram object

--- a/R/functions-Chromatogram.R
+++ b/R/functions-Chromatogram.R
@@ -90,8 +90,11 @@ names(.SUPPORTED_AGG_FUN_CHROM) <-
 #'     was used to aggregate intensity values for the same retention time across
 #'     the mz range. Supported are \code{"sum"} (total ion chromatogram),
 #'     \code{"max"} (base peak chromatogram), \code{"min"} and \code{"mean"}.
+#'
+#' @param msLevel \code{integer} with the MS level from which the chromatogram
+#'     was extracted.
 #' 
-#' @slot .__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun See corresponding parameter above.
+#' @slot .__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun,msLevel See corresponding parameter above.
 #' 
 #' @rdname Chromatogram-class
 Chromatogram <- function(rtime = numeric(), intensity = numeric(),
@@ -100,7 +103,8 @@ Chromatogram <- function(rtime = numeric(), intensity = numeric(),
                          precursorMz = c(NA_real_, NA_real_),
                          productMz = c(NA_real_, NA_real_),
                          fromFile = integer(),
-                         aggregationFun = character()) {
+                         aggregationFun = character(),
+                         msLevel = 1L) {
     ## Check if we have to re-order the data (issue #145).
     if (is.unsorted(rtime)) {
         idx <- order(rtime)
@@ -110,7 +114,8 @@ Chromatogram <- function(rtime = numeric(), intensity = numeric(),
     new("Chromatogram", rtime = rtime, intensity = intensity,
         mz = range(mz), filterMz = range(filterMz),
         precursorMz = range(precursorMz), productMz = range(productMz),
-        fromFile = as.integer(fromFile), aggregationFun = aggregationFun)
+        fromFile = as.integer(fromFile), aggregationFun = aggregationFun,
+        msLevel = msLevel)
 }
 
 #' @description Plot a single Chromatogram object

--- a/R/methods-Chromatogram.R
+++ b/R/methods-Chromatogram.R
@@ -19,6 +19,7 @@ setMethod("show", "Chromatogram", function(object) {
         rtr <- range(object@rtime)
         cat("rt range: [", rtr[1], ", ", rtr[2], "]\n", sep = "")
     }
+    cat("MS level: ", paste(object@msLevel, collapse = ", "), "\n", sep = "")
 })
 
 #' @description \code{rtime} returns the retention times for the rentention time
@@ -188,3 +189,10 @@ setMethod("plot", signature = signature("Chromatogram"),
               .plotChromatogram(x = x, col = col, lty = lty, type = type,
                                 xlab = xlab, ylab = ylab, main = main, ...)
           })
+
+#' @description \code{msLevel} returns the MS level of the chromatogram.
+#' 
+#' @rdname Chromatogram-class
+setMethod("msLevel", "Chromatogram", function(object) {
+    object@msLevel
+})

--- a/R/methods-MSnExp.R
+++ b/R/methods-MSnExp.R
@@ -430,6 +430,9 @@ setMethod("splitByFile", c("MSnExp", "factor"), function(object, f) {
 #'     if for a given retention time (spectrum) no signal was measured within
 #'     the mz range. Defaults to \code{NA_real_}.
 #'
+#' @param msLevel \code{integer} specifying the MS level from which the
+#'     chromatogram should be extracted. Defaults to \code{msLevel = 1L}.
+#'
 #' @param BPPARAM Parallelisation backend to be used, which will
 #'     depend on the architecture. Default is
 #'     \code{BiocParallel::bparam()}.
@@ -488,6 +491,7 @@ setMethod("splitByFile", c("MSnExp", "factor"), function(object, f) {
 setMethod("chromatogram", "MSnExp", function(object, rt, mz,
                                              aggregationFun = "sum",
                                              missing = NA_real_,
+                                             msLevel = 1L,
                                              BPPARAM = bpparam()){
     if (!missing(rt))
         if (is.null(ncol(rt)))
@@ -498,6 +502,7 @@ setMethod("chromatogram", "MSnExp", function(object, rt, mz,
     res <- .extractMultipleChromatograms(object, rt = rt, mz = mz,
                                          aggregationFun = aggregationFun,
                                          missingValue = missing,
+                                         msLevel = msLevel,
                                          BPPARAM = BPPARAM)
     res <- as(res, "Chromatograms")
     res@phenoData <- object@phenoData

--- a/man/Chromatogram-class.Rd
+++ b/man/Chromatogram-class.Rd
@@ -18,12 +18,13 @@
 \alias{filterRt,Chromatogram-method}
 \alias{clean,Chromatogram-method}
 \alias{plot,Chromatogram,ANY-method}
+\alias{msLevel,Chromatogram-method}
 \title{Representation of chromatographic MS data}
 \usage{
 Chromatogram(rtime = numeric(), intensity = numeric(), mz = c(NA_real_,
   NA_real_), filterMz = c(NA_real_, NA_real_), precursorMz = c(NA_real_,
   NA_real_), productMz = c(NA_real_, NA_real_), fromFile = integer(),
-  aggregationFun = character())
+  aggregationFun = character(), msLevel = 1L)
 
 aggregationFun(object)
 
@@ -52,6 +53,8 @@ productMz(object)
 \S4method{plot}{Chromatogram,ANY}(x, col = "#00000060", lty = 1,
   type = "l", xlab = "retention time", ylab = "intensity", main = NULL,
   ...)
+
+\S4method{msLevel}{Chromatogram}(object)
 }
 \arguments{
 \item{rtime}{\code{numeric} with the retention times (length has to be equal
@@ -83,6 +86,9 @@ from which the chromatogram was extracted.}
 was used to aggregate intensity values for the same retention time across
 the mz range. Supported are \code{"sum"} (total ion chromatogram),
 \code{"max"} (base peak chromatogram), \code{"min"} and \code{"mean"}.}
+
+\item{msLevel}{\code{integer} with the MS level from which the chromatogram
+was extracted.}
 
 \item{object}{A \code{Chromatogram} object.}
 
@@ -168,6 +174,8 @@ The \code{Chromatogram} class is designed to store
     \code{\link{clean}} documentation for more details and examples.
 
 \code{plot}: plots a \code{Chromatogram} object.
+
+\code{msLevel} returns the MS level of the chromatogram.
 }
 \details{
 The \code{mz}, \code{filterMz}, \code{precursorMz} and
@@ -185,7 +193,7 @@ The \code{mz}, \code{filterMz}, \code{precursorMz} and
 \section{Slots}{
 
 \describe{
-\item{\code{.__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun}}{See corresponding parameter above.}
+\item{\code{.__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun,msLevel}}{See corresponding parameter above.}
 }}
 
 \examples{

--- a/man/chromatogram-MSnExp-method.Rd
+++ b/man/chromatogram-MSnExp-method.Rd
@@ -7,7 +7,7 @@
 \title{Extract chromatogram object(s)}
 \usage{
 \S4method{chromatogram}{MSnExp}(object, rt, mz, aggregationFun = "sum",
-  missing = NA_real_, BPPARAM = bpparam())
+  missing = NA_real_, msLevel = 1L, BPPARAM = bpparam())
 }
 \arguments{
 \item{object}{For \code{chromatogram}: a \code{\linkS4class{MSnExp}} or
@@ -34,6 +34,9 @@ intensity value aggregation along the mz dimension. Allowed values are
 \item{missing}{\code{numeric(1)} allowing to specify the intensity value for
 if for a given retention time (spectrum) no signal was measured within
 the mz range. Defaults to \code{NA_real_}.}
+
+\item{msLevel}{\code{integer} specifying the MS level from which the
+chromatogram should be extracted. Defaults to \code{msLevel = 1L}.}
 
 \item{BPPARAM}{Parallelisation backend to be used, which will
 depend on the architecture. Default is

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -456,4 +456,7 @@ test_that("chromatogram,MSnExp works", {
     chrs <- chromatogram(inMem)
     rownames(pd) <- colnames(chrs)
     expect_equal(pData(chrs), pd)
+
+    chrs_2 <- chromatogram(inMem, msLevel = 1:4)
+    expect_equal(chrs, chrs_2)
 })

--- a/tests/testthat/test_OnDiskMSnExp.R
+++ b/tests/testthat/test_OnDiskMSnExp.R
@@ -375,6 +375,10 @@ test_that("chromatogram,OnDiskMSnExp works", {
     expect_equal(nrow(tmp), 0)
     tmp <- chromatogram(onDisk, rt = rtr, msLevel = 1:10)
     expect_equal(tmp, res)
+
+    res <- MSnbase:::.extractMultipleChromatograms(onDisk, rt = rtr,
+                                                   msLevel = 1:5)
+    expect_equal(tmp, res)    
 })
 
 ## Test the two versions that could/might be called by the

--- a/tests/testthat/test_OnDiskMSnExp.R
+++ b/tests/testthat/test_OnDiskMSnExp.R
@@ -349,6 +349,7 @@ test_that("chromatogram,OnDiskMSnExp works", {
     rtr <- matrix(c(280, 300, 20, 40), nrow = 2,
                   byrow = TRUE)  ## Only present in first, or 2nd file
     res <- chromatogram(onDisk, rt = rtr)
+    expect_true(all(unlist(lapply(res, msLevel)) == 1))
     ## Check fromFile
     for (i in 1:ncol(res))
         expect_true(all(sapply(res[, i], fromFile) == i))
@@ -368,6 +369,12 @@ test_that("chromatogram,OnDiskMSnExp works", {
     spctr <- split(spectra(flt), fromFile(flt))
     ints <- unlist(lapply(spctr[[1]], function(z) sum(intensity(z))))
     expect_equal(ints, intensity(res[2, 2]))
+
+    ## Check chromatogram with non-present MS level
+    expect_warning(tmp <- chromatogram(onDisk, rt = rtr, msLevel = 2L))
+    expect_equal(nrow(tmp), 0)
+    tmp <- chromatogram(onDisk, rt = rtr, msLevel = 1:10)
+    expect_equal(tmp, res)
 })
 
 ## Test the two versions that could/might be called by the

--- a/tests/testthat/test_OnDiskMSnExp.R
+++ b/tests/testthat/test_OnDiskMSnExp.R
@@ -378,7 +378,10 @@ test_that("chromatogram,OnDiskMSnExp works", {
 
     res <- MSnbase:::.extractMultipleChromatograms(onDisk, rt = rtr,
                                                    msLevel = 1:5)
-    expect_equal(tmp, res)    
+    colnames(res) <- basename(fileNames(onDisk))
+    res <- as(res, "Chromatograms")
+    pData(res) <- pData(onDisk)
+    expect_equal(tmp, res)
 })
 
 ## Test the two versions that could/might be called by the

--- a/tests/testthat/test_functions-Chromatogram.R
+++ b/tests/testthat/test_functions-Chromatogram.R
@@ -31,6 +31,9 @@ test_that("Chromatogram construction works", {
     expect_error(Chromatogram(aggregationFun = "other"))
     chr@aggregationFun <- "max"
     expect_true(validObject(chr))
+
+    chr_2 <- Chromatogram(intensity = int, rtime = rt, msLevel = 2L)
+    expect_equal(chr_2@msLevel, 2L)
 })
 
 test_that(".plotChromatogram works", {

--- a/tests/testthat/test_methods-Chromatogram.R
+++ b/tests/testthat/test_methods-Chromatogram.R
@@ -55,7 +55,9 @@ test_that("Chromatogram accessors", {
     chr@msLevel <- 1:4
     expect_equal(msLevel(chr), 1:4)
     expect_true(validObject(chr))
-    
+
+    chr <- Chromatogram(intensity = int, rt = rt, msLevel = 4)
+    expect_equal(msLevel(chr), 4L)
 })
 
 test_that("clean,Chromatogram works", {

--- a/tests/testthat/test_methods-Chromatogram.R
+++ b/tests/testthat/test_methods-Chromatogram.R
@@ -47,6 +47,15 @@ test_that("Chromatogram accessors", {
     expect_equal(productMz(chr), 432)
     chr <- Chromatogram(intensity = int, rt = rt, productMz = 432)
     expect_equal(productMz(chr), c(432, 432))
+
+    ## msLevel
+    chr@msLevel <- 2L
+    expect_equal(msLevel(chr), 2L)
+    expect_true(validObject(chr))
+    chr@msLevel <- 1:4
+    expect_equal(msLevel(chr), 1:4)
+    expect_true(validObject(chr))
+    
 })
 
 test_that("clean,Chromatogram works", {


### PR DESCRIPTION
- Add `msLevel` slot to `Chromatogram` class.
- Add `msLevel` argument to `chromatogram,MSnExp` (issue #246).
- Add `msLevel,Chromatogram` method.
- Update documentation and add unit tests.

See issue #246 for the initial discussion.