### PR TITLE
Don't overwrite processingData slot in initialize,MSnSet; fixes #264

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Changes in version 2.3.11
+-------------------------
+- Amend `addIdentificationData` when sourceInfo reports multiple files
+  and when scores are missing from the identification results (closes
+  #261).
+- Don't overwrite `processingData` slot when creating an `MSnSet` object
+  (closes #264).
+
 Changes in version 2.3.10
 -------------------------
 - New `isCentroidedFromFile` function <2017-08-11 Fri>

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,10 @@
 
 ## Changes in version 2.3.11
 - Amend `addIdentificationData` when sourceInfo reports multiple files
-  and when scores are missing from the identification resulst (closes
+  and when scores are missing from the identification results (closes
   #261).
+- Don't overwrite `processingData` slot when creating an `MSnSet` object
+  (closes #264).
 
 ## Changes in version 2.3.10
 - New `isCentroidedFromFile` function <2017-08-11 Fri>

--- a/R/methods-MSnSet.R
+++ b/R/methods-MSnSet.R
@@ -10,37 +10,41 @@ setMethod("initialize", "MSnSet",
                    phenoData,
                    featureData,
                    experimentData,
+                   processingData,
                    exprs = new("matrix"),
                    ... ) {
+
+            if (missing(experimentData))
+              experimentData <- new("MIAPE")
+            if (missing(processingData))
+              processingData <- new("MSnProcess")
+
             if (missing(assayData)) {
               if (missing(phenoData))
                 phenoData <- annotatedDataFrameFrom(exprs, byrow = FALSE)
               if (missing(featureData))
                 featureData <- annotatedDataFrameFrom(exprs, byrow = TRUE)
-              if (missing(experimentData))
-                experimentData <- new("MIAPE")
               .Object <- callNextMethod(.Object,
                                         phenoData = phenoData,
                                         featureData = featureData,
                                         exprs = exprs,
                                         experimentData = experimentData,
+                                        processingData = processingData,
                                         ...)
             } else if (missing(exprs)) {
               if (missing(phenoData))
                 phenoData <- annotatedDataFrameFrom(assayData, byrow = FALSE)
               if (missing(featureData))
                 featureData <- annotatedDataFrameFrom(assayData, byrow = TRUE)
-              if (missing(experimentData))
-                experimentData <- new("MIAPE")
               .Object <- callNextMethod(.Object,
                                         assayData = assayData,
                                         phenoData = phenoData,
                                         featureData = featureData,
                                         experimentData = experimentData,
+                                        processingData = processingData,
                                         ...)
             } else stop("provide at most one of 'assayData' or 'exprs' to initialize MSnSet",
                      call. = FALSE)
-            .Object@processingData <- new("MSnProcess")
             if (validObject(.Object))
               Biobase:::.harmonizeDimnames(.Object)
           })
@@ -246,9 +250,8 @@ t.MSnSet <- function(x) {
              phenoData = featureData(x),
              featureData = phenoData(x),
              experimentData = experimentData(x),
+             processingData = processingData(x),
              annotation = annotation(x))
-  ans@processingData@processing <-
-      x@processingData@processing
   ans <- logging(ans, "MSnSet transposed")
   if (validObject(ans))
       return(ans)

--- a/R/quantitation-MS2-isobaric.R
+++ b/R/quantitation-MS2-isobaric.R
@@ -61,10 +61,8 @@ quantify_MSnExp <- function(object, method,
                   experimentData = experimentData(object),
                   phenoData = .phenoData,
                   featureData = .featureData,
+                  processingData = processingData(object),
                   annotation = "No annotation")
-
-    ## copying processingData
-    msnset@processingData <- object@processingData
 
     ## Updating protocol slot
     if (nrow(protocolData(object)) > 0) {
@@ -180,9 +178,9 @@ quantify_OnDiskMSnExp_max <- function(object, reporters,
     ans <- new("MSnSet",
                exprs = e,
                featureData = featureData(object),
-               phenoData = .phenoData)
+               phenoData = .phenoData,
+               processingData = processingData(object))
     fData(ans)$reporterMzs <- mzs
-    ans@processingData <- object@processingData
     ans <- logging(ans, paste0("Fast ", names(reporters),
                                " quantitation by max"))
     if (validObject(ans)) ans

--- a/R/quantitation-MS2-labelfree.R
+++ b/R/quantitation-MS2-labelfree.R
@@ -25,7 +25,7 @@ count_MSnSet <- function(object, pepseq) {
                   exprs = .exprs,
                   experimentData = experimentData(object),
                   phenoData = phenoData(object),
-                  processingData = object@processingData,
+                  processingData = processingData(object),
                   featureData = .featureData,
                   annotation = "No annotation")
 
@@ -60,7 +60,7 @@ tic_MSnSet <- function(object) {
                   exprs = .exprs,
                   experimentData = experimentData(object),
                   phenoData = phenoData(object),
-                  processingData = object@processingData,
+                  processingData = processingData(object),
                   featureData = .featureData,
                   annotation = "No annotation")
 


### PR DESCRIPTION
This should be a trivial and non-invasive change to fix #264. I didn't merge it directly into master because:

1. I am not sure if you want a change an `initialize` method a few days before the next bioc release.
2. I got 49 failed unit tests. IMHO they are not related to this PR but have something to do with `OnDiskMSnExp`:

```
1. Error: addIdentificationData to OnDiskMSnExp (@test_MSnExp.R#224) -----------
"Multi_Spectrum2_constructor_mz_sorted" not available for .Call() for package "MSnbase"
...
49. Error: readMSData inMemory and onDisk reading CDF (@test_readMSData2.R#76) -
"Multi_Spectrum1_constructor_mz_sorted" not available for .Call() for package "MSnbase"
```

@lgatto and @jotsetung Do you have an idea why this `.Call` is not available? Do you need more information (`R CMD check` fails with the same error: [00check.log.txt](https://github.com/lgatto/MSnbase/files/1353905/00check.log.txt), [sessionInfo.txt](https://github.com/lgatto/MSnbase/files/1353903/sessionInfo.txt), [testthat.Rout.fail.txt](https://github.com/lgatto/MSnbase/files/1353904/testthat.Rout.fail.txt))?