### PR TITLE
Guess file type from file content (issue #275)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1161,8 +1161,29 @@ countAndPrint <- function(x) {
     } else if (grepl("\\.cdf($|\\.)|\\.nc($|\\.)", x, ignore.case = TRUE)) {
         return("netCDF")
     } else {
-        stop("Could not determine file type for ", x)
+        return(.mzRBackendFromContent(x))
     }
+}
+
+#' Determine the backend from the (first few lines of the) file content.
+#' 
+#' @author Johannes Rainer
+#'
+#' @noRd
+.mzRBackendFromContent <- function(x = character()) {
+    if (length(x) != 1)
+        stop("parameter 'x' has to be of length 1")
+    suppressWarnings(
+        first_lines <- readLines(x, n = 4)
+    )
+    if (any(grepl("<mzML", first_lines)) | any(grepl("<mzXML", first_lines))) {
+        return("pwiz")
+    } else if (any(grepl("<mzData", first_lines))) {
+        return("Ramp")
+    } else if (substr(readBin(x, character(), n = 1), 1, 3) == "CDF") {
+        return("netCDF")
+    } else
+        stop("Could not determine file type for ", x)        
 }
 
 #' @title Open an MS file using the mzR package

--- a/tests/testthat/test_readMSData2.R
+++ b/tests/testthat/test_readMSData2.R
@@ -75,3 +75,12 @@ test_that("readMSData inMemory and onDisk reading CDF", {
     mse <- readMSData(f, msLevel. = 1, mode = "inMemory")
     all.equal(spectra(odmse), spectra(mse))
 })
+
+test_that(".mzRBackendFromContent works", {
+    library(msdata)
+    f <- system.file("cdf/ko15.CDF",  package = "msdata")
+    expect_equal(MSnbase:::.mzRBackendFromContent(f), "netCDF")
+    mzf <- proteomics(full.name = TRUE,
+                      pattern = "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzML.gz")
+    expect_equal(MSnbase:::.mzRBackendFromContent(mzf), "pwiz")
+})


### PR DESCRIPTION
- If the file extension is unknown, guess file type by its content.
- Works also for compressed files.
- Add related unit tests.