### PR TITLE
Reduce number of comparisons in fastquant_max

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,11 @@
 Changes in version 2.5.2
 ------------------------
-- Nothing yet
+- Reduce number of comparsions in in internal `fastquant_max` to get little
+    speed improvents for isobaric quantification (see PR #280) <2017-11-27 Mon>.
 
 Changes in version 2.5.1
 ------------------------
-- Update dependencies (see issue [#271](https://github.com/lgatto/MSnbase/issues/271))
+- Update dependencies (see issue #271)
 - Replace HCD by ETD in TMT10ETD's name/description
 
 Changes in version 2.5.0
@@ -28,15 +29,15 @@ Changes in version 2.3.13
 
 Changes in version 2.3.12
 -------------------------
-- Keep `protocolData` in isobaric quantification; fixes [#265](https://github.com/lgatto/MSnbase/issues/265)
+- Keep `protocolData` in isobaric quantification; fixes #265
 
 Changes in version 2.3.11
 -------------------------
 - Amend `addIdentificationData` when sourceInfo reports multiple files
   and when scores are missing from the identification results (closes
-  [#261](https://github.com/lgatto/MSnbase/issues/261)).
+  #261).
 - Don't overwrite `processingData` slot when creating an `MSnSet` object
-  (closes [#264](https://github.com/lgatto/MSnbase/issues/264)).
+  (closes #264).
 
 Changes in version 2.3.10
 -------------------------
@@ -44,16 +45,16 @@ Changes in version 2.3.10
 - Add msLevel slot to Chromatogram object <2017-08-16 Wed>
 - Add msLevel argument to chromatogram,MSnExp method <2017-08-16 Wed>
 - `calculateFragments` now just calculate fragments for all `n - 1L` bonds
-    (before it incorrectly adds an additional bond; fixes [#248](https://github.com/lgatto/MSnbase/issues/248)) <2017-08-20 Sun>
+    (before it incorrectly adds an additional bond; fixes #248) <2017-08-20 Sun>
 - Add `isEmpty` methods for `Chromatogram` and `Chromatograms` objects
   <2017-09-05 Tue>
 - plot,Chromatogram[s] creates an empty plot and returns a warning if the
-  Chromatogram[s] object is empty (issue [#249](https://github.com/lgatto/MSnbase/issues/249)) <2017-09-05 Tue>
+  Chromatogram[s] object is empty (issue #249) <2017-09-05 Tue>
 
 Changes in version 2.3.9
 ------------------------
 - Using new mzR::openIdfile backend to add identifcation data to raw
-  and quantitative data (see issue [#232](https://github.com/lgatto/MSnbase/issues/232)) <2017-07-28 Fri>
+  and quantitative data (see issue #232) <2017-07-28 Fri>
 - New utils functions: factorsAsStrings, makeCamelCase and
   reduce,data.frame <2017-07-29 Sat>
 - Coerce mzRident to data.frames <2017-07-29 Sat>
@@ -71,7 +72,7 @@ Changes in version 2.3.8
 - New infrastructure for chromatogram data <2017-06-24 Sat>
 - Change naming scheme for spectra: FFILEID.SSPECTRUMID, e.g. F01.S0001. Before
   it has been XSPECTRUMID.FILEID. The new naming scheme changes the order of
-  the spectra. See [#255](https://github.com/lgatto/MSnbase/issues/255) (and PR [#256](https://github.com/lgatto/MSnbase/issues/256)) for details <2017-06-25 Sun>.
+  the spectra. See #255 (and PR #256) for details <2017-06-25 Sun>.
 
 Changes in version 2.3.7
 ------------------------
@@ -88,7 +89,7 @@ Changes in version 2.3.5
 
 Changes in version 2.3.4
 ------------------------
-- Use the injection time from mzR (see PR [#109](https://github.com/lgatto/MSnbase/issues/109)) which in now in
+- Use the injection time from mzR (see PR #109) which in now in
   seconds (was in milliseconds) <2017-06-13 Tue>
 
 Changes in version 2.3.3
@@ -104,14 +105,14 @@ Changes in version 2.3.3
 Changes in version 2.3.2
 ------------------------
 - Rewrite `utils.clean`. It now keeps just the zeros in the direct
-  neighbourhood (see [#210](https://github.com/lgatto/MSnbase/issues/210)) <2017-05-04 Thu>.
+  neighbourhood (see #210) <2017-05-04 Thu>.
 
 Changes in version 2.3.1
 ------------------------
 - Introduce "NTR" method for `combineFeatures` <2017-04-26 Wed>.
 - Rewrite `nQuants` and `featureCV` to avoid returning of rows for empty
-  factors; see PR [#208](https://github.com/lgatto/MSnbase/issues/208) for details <2017-04-28 Fri>.
-- Add $,pSet method to easily access columns in the phenoData (see [#203](https://github.com/lgatto/MSnbase/issues/203))
+  factors; see PR #208 for details <2017-04-28 Fri>.
+- Add $,pSet method to easily access columns in the phenoData (see #203)
 
 Changes in version 2.3.0
 ------------------------
@@ -128,7 +129,7 @@ Changes in version 2.2.0
 Changes in version 2.1.19
 -------------------------
 - Set SerialParams() in an attempt to avoid random errors in tests -
-  see issue [#205](https://github.com/lgatto/MSnbase/issues/205) <2017-04-24 Mon>
+  see issue #205 <2017-04-24 Mon>
 
 Changes in version 2.1.18
 -------------------------
@@ -145,15 +146,15 @@ Changes in version 2.1.16
 
 Changes in version 2.1.15
 -------------------------
-- Remove reshape2 dependency; see [#201](https://github.com/lgatto/MSnbase/issues/201) <2017-04-06 Thu>
+- Remove reshape2 dependency; see #201 <2017-04-06 Thu>
 
 Changes in version 2.1.14
 -------------------------
 - Internal rewrite and speedup of topN; Briefly multiple apply calls are
   avoided, `getTopIdx` and `subsetById` are replaced by `.topIdx`.
-  See PR [#199](https://github.com/lgatto/MSnbase/issues/199) for details. <2017-03-20 Mon>
+  See PR #199 for details. <2017-03-20 Mon>
 - Fix mz calculation for terminal modifications and z > 1 in
-  `calculateFragments`; closes [#200](https://github.com/lgatto/MSnbase/issues/200) <2017-03-22 Wed>
+  `calculateFragments`; closes #200 <2017-03-22 Wed>
 - Fix errors and notes <2017-03-30 Thu>
 
 Changes in version 2.1.13
@@ -167,8 +168,8 @@ Changes in version 2.1.12
 
 Changes in version 2.1.11
 -------------------------
-- Fix breaks calculation for binning single (closes [#191](https://github.com/lgatto/MSnbase/issues/191)) and multiple
-  (closes [#190](https://github.com/lgatto/MSnbase/issues/190)) spectra. The fix for single spectra ([#191](https://github.com/lgatto/MSnbase/issues/191)) could result in
+- Fix breaks calculation for binning single (closes #191) and multiple
+  (closes #190) spectra. The fix for single spectra (#191) could result in
   slightly different breaks on the upper end of the m/z values. <2017-02-10 Fri>
 - New `aggvar` function, to assess aggregation variability
   <2017-02-11 Sat>
@@ -182,10 +183,10 @@ Changes in version 2.1.9
 ------------------------
 - When fully trimmed, an (empty) spectrum has peaksCount of 0L - see
   https://github.com/https://github.com/lgatto/MSnbase/issues/184 <2017-01-20 Fri>
-- Add filterEmptySpectra,MSnExp method (see issue [#181](https://github.com/lgatto/MSnbase/issues/181))
+- Add filterEmptySpectra,MSnExp method (see issue #181)
   <2017-01-20 Fri>
 - Add a section about notable on-disk and in-memory differences (was
-  issue [#165](https://github.com/lgatto/MSnbase/issues/165)) <2017-01-20 Fri>
+  issue #165) <2017-01-20 Fri>
 
 Changes in version 2.1.8
 ------------------------
@@ -198,10 +199,10 @@ Changes in version 2.1.7
 - Setting default sorting using "auto" on R < 3.3 and "radix"
   otherwise <2017-01-03 Tue>
 - filterMz returns an empty spectrum when no data is within the mz
-  range (see issue [#181](https://github.com/lgatto/MSnbase/issues/181)) <2017-01-16 Mon>
+  range (see issue #181) <2017-01-16 Mon>
 - Performance improvement: a new private .firstMsLevel will
   efficiently return the first MS level in an MSnExp and
-  OnDiskMSnExp. See issue [#183](https://github.com/lgatto/MSnbase/issues/183) for details/background <2017-01-18 Wed>
+  OnDiskMSnExp. See issue #183 for details/background <2017-01-18 Wed>
 
 Changes in version 2.1.6
 ------------------------
@@ -228,14 +229,14 @@ Changes in version 2.1.3
 ------------------------
 
  - FeaturesOfInterest collections can now be assigned names -
-   addresses issue [#172](https://github.com/lgatto/MSnbase/issues/172) <2016-11-25 Fri>
+   addresses issue #172 <2016-11-25 Fri>
 
 Changes in version 2.1.2
 ------------------------
 
  - Update readMSnSet2 to save filename <2016-11-09 Wed>
  - Ensure that header information is read too if spectra data is
-   loaded for onDiskMSnExp objects (see issue [#170](https://github.com/lgatto/MSnbase/issues/170)) <2016-11-24 Thu>
+   loaded for onDiskMSnExp objects (see issue #170) <2016-11-24 Thu>
 
 Changes in version 2.1.1
 ------------------------
@@ -254,16 +255,16 @@ Changes in version 2.1.0
 
 Changes in version 1.99.6
 -------------------------
- - Reverting to old initialize,Spectrum (see issue [#163](https://github.com/lgatto/MSnbase/issues/163))
+ - Reverting to old initialize,Spectrum (see issue #163)
    <2016-10-07 Fri>
  - Setting Spectrum class versions outside of prototype (see issue
-   [#163](https://github.com/lgatto/MSnbase/issues/163)). For this, there is now a vector of class version in
+   #163). For this, there is now a vector of class version in
    .MSnbaseEnv <2016-10-10 Mon>
 
 Changes in version 1.99.5
 -------------------------
 
- - Add removeReporters,OnDiskMSnExp (see issue [#161](https://github.com/lgatto/MSnbase/issues/161) for details)
+ - Add removeReporters,OnDiskMSnExp (see issue #161 for details)
    <2016-10-07 Fri>
 
 Changes in version 1.99.4
@@ -275,7 +276,7 @@ Changes in version 1.99.3
 -------------------------
 
  - Injection time is now added to the header when reading mzML files
-   using readMSData2 (see issue [#159](https://github.com/lgatto/MSnbase/issues/159)) <2016-10-04 Tue>
+   using readMSData2 (see issue #159) <2016-10-04 Tue>
 
 Changes in version 1.99.2
 -------------------------
@@ -331,11 +332,11 @@ Changes in version 1.99.0
  - In onDiskMSnExp validity, check that the assaydata is empty
    <2016-06-28 Tue>
  - Pass neutralLoss in plot,Spectrum,Spectrum-method to
-   .calculateFragments; fixes [#146](https://github.com/lgatto/MSnbase/issues/146) <2016-08-12 Fri>
+   .calculateFragments; fixes #146 <2016-08-12 Fri>
  - Allow the user to specify the `cex`, `lwd`, `pch` for peaks and
-   fragments in plot,Spectrum,Spectrum-method; closes [#148](https://github.com/lgatto/MSnbase/issues/148)
+   fragments in plot,Spectrum,Spectrum-method; closes #148
    <2016-08-12 Fri>
- - Update centroided with an na.fail argument (see issue [#150](https://github.com/lgatto/MSnbase/issues/150) for
+ - Update centroided with an na.fail argument (see issue #150 for
    details) <2016-08-12 Fri>
  - Fix warning in readMgfData if TITLE contains multiple "=" <2016-08-24 Wed>
 
@@ -346,16 +347,16 @@ Changes in version 1.21.8
  - Update MSnSet validity method to guard agains empty string feature
    names <2016-06-20 Mon>
  - Simplify show,MSnExp method to work for various MS level cases and
-   onDiskMSnExp - addressed issue [#98](https://github.com/lgatto/MSnbase/issues/98) <2016-06-28 Tue>
+   onDiskMSnExp - addressed issue #98 <2016-06-28 Tue>
  - removeMultipleAssignment also removes features that were not
    assigned (i.e. that have fcol (nprots) NA) <2016-07-02 Sat>
  - New smoothed slot/accessor/replacement methods <2016-07-08 Fri>
  - Update reporter masses and add TMT10 ETD/HCD <2016-07-20 Wed>
  - returning empty spectrum when fliterMz has empty range - see issue
-   [#134](https://github.com/lgatto/MSnbase/issues/134) <2016-07-22 Fri>
+   #134 <2016-07-22 Fri>
  - (mz, intensity) values are reordered based on order(mz) - see issue
-   [#135](https://github.com/lgatto/MSnbase/issues/135) <2016-07-26 Tue>
- - fix bug in bin,Spectrum - see issue [#137](https://github.com/lgatto/MSnbase/issues/137) <2016-08-05 Fri>
+   #135 <2016-07-26 Tue>
+ - fix bug in bin,Spectrum - see issue #137 <2016-08-05 Fri>
 
 Changes in version 1.21.7
 -------------------------
@@ -363,9 +364,9 @@ Changes in version 1.21.7
  - Update iPQF reference <2016-06-01 Wed>
  - Fix a bug in normalize method for MSnExp objects: assigning
    normalized spectra directly to assayData is not possible, as the
-   environment is locked. See PR [#91](https://github.com/lgatto/MSnbase/issues/91).
+   environment is locked. See PR #91.
  - readMSData: if no phenodata is provided it creates an empty one
-   with rownames corresponding to the file names. See PR [#91](https://github.com/lgatto/MSnbase/issues/91).
+   with rownames corresponding to the file names. See PR #91.
  - Lock itraqdata's assaydata bindings <2016-06-08 Wed>
 
 Changes in version 1.21.6
@@ -385,7 +386,7 @@ Changes in version 1.21.4
 -------------------------
 
  - More MzTab and Spectrum1 unit testing <2016-05-08 Sun>
- - Speed up readMSData (PR [#86](https://github.com/lgatto/MSnbase/issues/86) by jotsetung) <2016-05-12 Thu>
+ - Speed up readMSData (PR #86 by jotsetung) <2016-05-12 Thu>
  - Replace example file URL to use github instead of googlecode
     <2016-05-12 Thu>
 
@@ -406,7 +407,7 @@ Changes in version 1.21.2
 Changes in version 1.21.1
 -------------------------
 
- - Fix wrong indexing in readMSdata, msLevel==1 (PR [#85](https://github.com/lgatto/MSnbase/issues/85) by jotsetung)
+ - Fix wrong indexing in readMSdata, msLevel==1 (PR #85 by jotsetung)
    <2016-05-04 Wed>
  - grep/getEcols have a 'n' param specifying which line to grep/get
    <2016-05-04 Wed>
@@ -470,7 +471,7 @@ Changes in version 1.19.17
 Changes in version 1.19.16
 --------------------------
 
- - add estimateNoise,[Spectrum|MSnExp]-method; closes [#78](https://github.com/lgatto/MSnbase/issues/78) <2016-03-10>
+ - add estimateNoise,[Spectrum|MSnExp]-method; closes #78 <2016-03-10>
  - import a lot of functions from recommended packages, namely graphics, stats
    and utils to avoid many "Undefined global functions or variables" NOTEs in
    R CMD check <2016-03-10>
@@ -507,7 +508,7 @@ Changes in version 1.19.12
 Changes in version 1.19.11
 --------------------------
 
- - Fix trimws generic/methods with useAsDefault (see issue [#75](https://github.com/lgatto/MSnbase/issues/75))
+ - Fix trimws generic/methods with useAsDefault (see issue #75)
    <2016-02-02 Tue>
  - add exprs,MSnSet-method alias (since exprs is now exported)
    <2016-02-02 Tue>
@@ -532,7 +533,7 @@ Changes in version 1.19.7
 -------------------------
 
  - new sampleNames<- for pSet and MSnExp objects <2015-12-15 Tue>
- - Fix bug preventing to write MS1 to mgf (fixes issue [#73](https://github.com/lgatto/MSnbase/issues/73) reported by
+ - Fix bug preventing to write MS1 to mgf (fixes issue #73 reported by
     meowcat) <2015-12-18 Fri>
 
 Changes in version 1.19.6
@@ -543,13 +544,13 @@ Changes in version 1.19.6
    <2015-12-14 Mon>
  - Update MSnbase:::subsetBy to use split instead of lapply, which
    makes topN faster. This nevertheless changes the order of the
-   resulting MSnSet (see issue [#63](https://github.com/lgatto/MSnbase/issues/63) for details and background);
+   resulting MSnSet (see issue #63 for details and background);
    contributed by sgibb <2015-12-14 Mon>
 
 Changes in version 1.19.5
 -------------------------
 
- - Merged pull request [#67](https://github.com/lgatto/MSnbase/issues/67) from lgatto/featureCV by sgibb: featureCV
+ - Merged pull request #67 from lgatto/featureCV by sgibb: featureCV
  ignores its na.rm argument <2015-12-12 Sat>
 
 Changes in version 1.19.4
@@ -589,7 +590,7 @@ Changes in version 1.18.0
 Changes in version 1.17.16
 --------------------------
  - new default parameter 'feature weight' in iPQF by Martina Fisher
-   (see PR[#65](https://github.com/lgatto/MSnbase/issues/65)) <2015-10-07 Wed>
+   (see PR#65) <2015-10-07 Wed>
 
 Changes in version 1.17.15
 --------------------------
@@ -606,7 +607,7 @@ Changes in version 1.17.13
 
  - partly rewrite writeMgfData <2015-05-16 Thu>
  - initial hmap function <2015-07-16 Thu>
- - fix bug in plotting MS1 spectra (closes issue [#59](https://github.com/lgatto/MSnbase/issues/59)) <2015-07-16 Thu>
+ - fix bug in plotting MS1 spectra (closes issue #59) <2015-07-16 Thu>
  - new image implementation, based on @vladpetyuk's
    vp.misc::image_msnset <2015-07-25 Sat>
  - Changed the deprecated warning to a message when reading MzTab data
@@ -637,9 +638,9 @@ Changes in version 1.17.9
 -------------------------
 
  - calculateFragments' "neutralLoss" argument is now a list (was a logical
-   before), see [#47](https://github.com/lgatto/MSnbase/issues/47). <2015-06-24 Wed>
+   before), see #47. <2015-06-24 Wed>
  - add defaultNeutralLoss() function to fill calculateFragments' modified
-  "neutralLoss" argument, see [#47](https://github.com/lgatto/MSnbase/issues/47). <2015-06-24 Wed>
+  "neutralLoss" argument, see #47. <2015-06-24 Wed>
 
 Changes in version 1.17.8
 -------------------------
@@ -662,7 +663,7 @@ Changes in version 1.17.6
    modification is added to the mass of the amino acid/peptide. Before it was
    replaced. <2015-06-21 Sun>
  - calculateFragments gains the feature to handle N-/C-terminal modifications,
-   see [#47](https://github.com/lgatto/MSnbase/issues/47). <2015-06-21 Sun>
+   see #47. <2015-06-21 Sun>
  - update readMzTabData example <2015-06-22 Mon>
 
 Changes in version 1.17.5
@@ -711,7 +712,7 @@ Changes in version 1.15.18
 --------------------------
  - fix failing test_MSnExp::readMSData unit test on Windows i386
    (@.cache$size being different on that arch) [2015-04-14 Tue]
- - merge @vladpetyuk PR [#50](https://github.com/lgatto/MSnbase/issues/50) fix of combine features bug [2015-04-14 Tue]
+ - merge @vladpetyuk PR #50 fix of combine features bug [2015-04-14 Tue]
 
 Changes in version 1.15.17
 --------------------------
@@ -768,13 +769,13 @@ Changes in version 1.15.7
 Changes in version 1.15.6
 -------------------------
 
- - add intensity column to the calculateFragments output; closes [#47](https://github.com/lgatto/MSnbase/issues/47);1
+ - add intensity column to the calculateFragments output; closes #47;1
    [2015-02-02 Mon]
  - add method argument to calculateFragments to allow the user choosing the
-   highest/closest peak or all peaks in the tolerance range; closes [#47](https://github.com/lgatto/MSnbase/issues/47);2
+   highest/closest peak or all peaks in the tolerance range; closes #47;2
    [2015-02-09 Mon]
  - add neutralLoss argument to calculateFragments and calculate loss of water
-   and ammonia; closes [#47](https://github.com/lgatto/MSnbase/issues/47):3 [2015-02-19 Thu]
+   and ammonia; closes #47:3 [2015-02-19 Thu]
  - new imputation methods via imputeLCMD and norm [2015-02-09 Mon]
  - vignette updates [2015-02-09 Mon]
  - imputation unit test [2015-02-24 Tue]
@@ -785,7 +786,7 @@ Changes in version 1.15.5
  - update dependency to mzID >= 1.5.2 [2015-01-28 Wed]
  - rewrite addIdentificationData and change its signature [2015-01-28 Wed]
  - add methods addIdentificationData which work on MSnExp and MSnSets using
-   filenames (characters), mzID objects and data.frames; see [#42](https://github.com/lgatto/MSnbase/issues/42); closes [#45](https://github.com/lgatto/MSnbase/issues/45);
+   filenames (characters), mzID objects and data.frames; see #42; closes #45;
    [2015-01-28 Wed]
  - add a section about MSmaps in the vignette [2015-02-02 Mon]
  - MSmap has a new zeroIsNA argument to set all 0 values of the map to
@@ -820,7 +821,7 @@ Changes in version 1.15.2
 Changes in version 1.15.1
 -------------------------
 
- - Fixing error when id file has no spectrumFile info (see issue [#39](https://github.com/lgatto/MSnbase/issues/39))
+ - Fixing error when id file has no spectrumFile info (see issue #39)
    and return a warning (instead of an error) when the file used to
    create the MSnExp/MSnSet and mzid file were different
    [2014-10-15 Wed]
@@ -995,7 +996,7 @@ Changes in version 1.11.8
 -------------------------
 
  - adding redundancy handling to combineFeatures (by vladpetyuk, pull
-   request [#18](https://github.com/lgatto/MSnbase/issues/18)) [2014-03-14 Fri]
+   request #18) [2014-03-14 Fri]
  - updated combineFeatures signature to accomodate above changes
    [2014-03-14 Fri]
  - updated unit tests for new testhat 0.8 [2014-03-14 Fri]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # MSnbase 2.5
 
 ## Changes in version 2.5.2
-- Nothing yet
+- Reduce number of comparsions in in internal `fastquant_max` to get little
+    speed improvents for isobaric quantification (see PR [#280](https://github.com/lgatto/MSnbase/issues/280)) <2017-11-27 Mon>.
 
 ## Changes in version 2.5.1
 - Update dependencies (see issue [#271](https://github.com/lgatto/MSnbase/issues/271))

--- a/R/quantitation-MS2-isobaric.R
+++ b/R/quantitation-MS2-isobaric.R
@@ -92,7 +92,7 @@ fastquant_max <- function(f, pk, spi, wd = 0.5) {
                          nrow = length(pks))
     for (i in seq_along(pks)) {
         for (ii in seq_along(pk)) {
-            k <- pks[[i]][, 1] >= pk[ii] - wd & pks[[i]][, 1] <= pk[ii] + wd
+            k <- abs(pks[[i]][, 1L] - pk[ii]) <= wd
             if (any(k)) {
                 j <- which.max(pks[[i]][k, 2])
                 res[i, ii] <- pks[[i]][k, , drop = FALSE][j, 2]


### PR DESCRIPTION
This PR is more or less just for documentation. It reduce the number of comparisons via `<=` and saves some time (if the peaks are already in memory speed gain is nearly two fold; for on disk objects it is just around 10%); see also #130.

```r
library("msdata")
library("MSnbase")
library("microbenchmark")
f <- msdata::proteomics(full.names = TRUE,
                        pattern = "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzML.gz")

fastquant_max2 <- function(f, pk, spi, wd = 0.5) {
    ramp <- MSnbase:::.openMSfile(f)
    on.exit(close(ramp))
    pks <- peaks(ramp, spi)
    if (length(spi) == 1)
        pks <- list(pks)
    mzs <- res <- matrix(NA_real_,
                         ncol = length(pk),
                         nrow = length(pks))
    for (i in seq_along(pks)) {
        for (ii in seq_along(pk)) {
            k <- abs(pks[[i]][, 1L] - pk[ii]) <= wd
            if (any(k)) {
                j <- which.max(pks[[i]][k, 2])
                res[i, ii] <- pks[[i]][k, , drop = FALSE][j, 2]
                mzs[i, ii] <- pks[[i]][k, , drop = FALSE][j, 1]
            }
        }
    }
    list(exprs = res,
         mzs = mzs)
}

all.equal(MSnbase:::fastquant_max(f, mz(TMT6), spi=1:509, wd=0.5),
          fastquant_max2(f, mz(TMT6), spi=1:509, wd=0.5))
# [1] TRUE

microbenchmark(MSnbase:::fastquant_max(f, mz(TMT6), spi=1:509, wd=0.5),
               fastquant_max2(f, mz(TMT6), spi=1:509, wd=0.5), times=10)

# MSnbase:::fastquant_max(f, mz(TMT6), spi = 1:509, wd = 0.5) 739.2620 746.6394
#          fastquant_max2(f, mz(TMT6), spi = 1:509, wd = 0.5) 682.8757 687.2723
#     mean   median       uq      max neval
# 765.8628 757.8052 760.7415 879.4974    10
# 718.0008 692.4549 700.9097 829.5581    10
```