### PR TITLE
Disable CV parameter MS:-1 for writeMSData (issue #321)

### DIFF
--- a/R/writeMSData.R
+++ b/R/writeMSData.R
@@ -146,9 +146,8 @@
     processings <- processingData(x)@processing
     if (length(processings)) {
         proc_cv <- unlist(lapply(processings, FUN = .pattern_to_cv))
-        ## Remove MS:-1 if we have also some mapped processings.
-        if (!all(proc_cv == "MS:-1"))
-            proc_cv <- proc_cv[proc_cv != "MS:-1"]
+        ## Remove all unknown processing steps (issue #321).
+        proc_cv <- proc_cv[!is.na(proc_cv)]
         msnbase_proc <- c(msnbase_proc, proc_cv)
     }
     res[[1]] <- msnbase_proc
@@ -169,7 +168,7 @@
 #' @param pattern `character(1)` with the pattern for which a CV term should be
 #'     returned.
 #'
-#' @param ifnotfound `character(1)` to be returned if none of the cv terms
+#' @param ifnotfound value to be returned if none of the cv terms
 #'     matches the pattern.
 #' 
 #' @param return `character` with the PSI-MS term or the value of `ifnotfound`
@@ -181,7 +180,7 @@
 #' @md
 #'
 #' @noRd
-.pattern_to_cv <- function(pattern, ifnotfound = "MS:-1") {
+.pattern_to_cv <- function(pattern, ifnotfound = NA_character_) {
     if (length(pattern) > 1) {
         warning("length of pattern is > 1, using only first element")
         pattern <- pattern[1]

--- a/tests/testthat/test_writeMSData.R
+++ b/tests/testthat/test_writeMSData.R
@@ -82,7 +82,7 @@ test_that("writeMSData works", {
 
 test_that(".pattern_to_cv works", {
     ## Not found.
-    expect_equal(.pattern_to_cv("unknown"), "MS:-1")
+    expect_equal(.pattern_to_cv("unknown"), NA_character_)
     expect_equal(.pattern_to_cv("peak picking"), "MS:1000035")
     expect_equal(.pattern_to_cv("centroid"), "MS:1000035")    
     expect_equal(.pattern_to_cv("Alignment/retention time adjustment"),
@@ -132,8 +132,13 @@ test_that(".guessSoftwareProcessing works", {
     res <- .guessSoftwareProcessing(odf_proc, c("other_soft", "43.2.1"))
     expect_equal(res[[1]][7], "MS:1001486")
     expect_equal(res[[2]], c("other_soft", "43.2.1"))
+    ## Check that we don't get unknown CV parameter.
+    odf_proc <- clean(tmt_erwinia_on_disk)
+    res <- .guessSoftwareProcessing(odf_proc)
+    expect_equal(res[[1]][1], "MSnbase")
+    expect_equal(res[[1]][2], paste0(packageVersion("MSnbase"), collapse = "."))
+    expect_true(length(res[[1]]) == 2)
 })
-
 
 test_that("writeMSData,OnDiskMSnExp works", {
     out_path <- tempdir()


### PR DESCRIPTION
- Don't add a CV parameter for unknown data processings.

This will be quite crucial once https://github.com/sneumann/mzR/issues/151 is fixed to ensure that we write valid mzML files.