### PR TITLE
Ensure that a MS CV term ID for the software is added

### DIFF
--- a/R/writeMSData.R
+++ b/R/writeMSData.R
@@ -141,13 +141,16 @@
 #' @noRd
 .guessSoftwareProcessing <- function(x, software_processing = NULL) {
     res <- list()
+    ## issue #321: replace MS:-1 with the MS CV Term of MSnbase, once it's
+    ## included.
     msnbase_proc <- c("MSnbase", paste0(packageVersion("MSnbase"),
-                                        collapse = "."))
+                                        collapse = "."), "MS:-1")
     processings <- processingData(x)@processing
     if (length(processings)) {
         proc_cv <- unlist(lapply(processings, FUN = .pattern_to_cv))
         ## Remove all unknown processing steps (issue #321).
         proc_cv <- proc_cv[!is.na(proc_cv)]
+        if (!all(proc_vb))
         msnbase_proc <- c(msnbase_proc, proc_cv)
     }
     res[[1]] <- msnbase_proc

--- a/R/writeMSData.R
+++ b/R/writeMSData.R
@@ -150,7 +150,6 @@
         proc_cv <- unlist(lapply(processings, FUN = .pattern_to_cv))
         ## Remove all unknown processing steps (issue #321).
         proc_cv <- proc_cv[!is.na(proc_cv)]
-        if (!all(proc_vb))
         msnbase_proc <- c(msnbase_proc, proc_cv)
     }
     res[[1]] <- msnbase_proc

--- a/tests/testthat/test_writeMSData.R
+++ b/tests/testthat/test_writeMSData.R
@@ -95,49 +95,50 @@ test_that(".guessSoftwareProcessing works", {
     res <- .guessSoftwareProcessing(odf_proc)
     expect_equal(res[[1]][1], "MSnbase")
     expect_equal(res[[1]][2], paste0(packageVersion("MSnbase"), collapse = "."))
-    expect_equal(res[[1]][3], "MS:1001486")
+    expect_equal(res[[1]][3], "MS:-1")
+    expect_equal(res[[1]][4], "MS:1001486")
     ## clean: Spectra cleaned NO CV YET
     ## bin: Spectra binned: NO CV YET
     ## removePeaks: Curves <= t set to '0': NO CV YET
     odf_proc <- removePeaks(odf_proc)
     res <- .guessSoftwareProcessing(odf_proc)
-    expect_equal(res[[1]][3], "MS:1001486")
-    expect_equal(length(res[[1]]), 3)
+    expect_equal(res[[1]][4], "MS:1001486")
+    expect_equal(length(res[[1]]), 4)
     ## normalise: Spectra normalised
     odf_proc <- normalise(odf_proc)
     res <- .guessSoftwareProcessing(odf_proc)
-    expect_equal(length(res[[1]]), 4)
-    expect_equal(res[[1]][3], "MS:1001486")
-    expect_equal(res[[1]][4], "MS:1001484")
+    expect_equal(length(res[[1]]), 5)
+    expect_equal(res[[1]][4], "MS:1001486")
+    expect_equal(res[[1]][5], "MS:1001484")
     ## pickPeaks: Spectra centroided
     odf_proc <- pickPeaks(odf_proc)
     res <- .guessSoftwareProcessing(odf_proc)
-    expect_equal(length(res[[1]]), 5)
-    expect_equal(res[[1]][5], "MS:1000035")
+    expect_equal(length(res[[1]]), 6)
+    expect_equal(res[[1]][6], "MS:1000035")
     ## smooth: Spectra smoothed
     odf_proc <- smooth(odf_proc)
     res <- .guessSoftwareProcessing(odf_proc)
-    expect_equal(length(res[[1]]), 6)
-    expect_equal(res[[1]][6], "MS:1000542")
+    expect_equal(length(res[[1]]), 7)
+    expect_equal(res[[1]][7], "MS:1000542")
     ## filterRt: Filter: select retention time
     odf_proc <- filterRt(odf_proc, rt = c(200, 600))
     res <- .guessSoftwareProcessing(odf_proc)
-    expect_equal(length(res[[1]]), 7)
-    expect_equal(res[[1]][7], "MS:1001486")
+    expect_equal(length(res[[1]]), 8)
+    expect_equal(res[[1]][8], "MS:1001486")
     ## filterMz: FilteR: trim MZ
     ## filterFile: Filter: select file(s)
     ## filterAcquisitionNum: Filter: select by
     ## filterEmptySpectra: Removed XXX empty spectra
     ## And with providing in addition other processings.
     res <- .guessSoftwareProcessing(odf_proc, c("other_soft", "43.2.1"))
-    expect_equal(res[[1]][7], "MS:1001486")
+    expect_equal(res[[1]][8], "MS:1001486")
     expect_equal(res[[2]], c("other_soft", "43.2.1"))
     ## Check that we don't get unknown CV parameter.
     odf_proc <- clean(tmt_erwinia_on_disk)
     res <- .guessSoftwareProcessing(odf_proc)
     expect_equal(res[[1]][1], "MSnbase")
     expect_equal(res[[1]][2], paste0(packageVersion("MSnbase"), collapse = "."))
-    expect_true(length(res[[1]]) == 2)
+    expect_true(length(res[[1]]) == 3)
 })
 
 test_that("writeMSData,OnDiskMSnExp works", {


### PR DESCRIPTION
Ensure that a MS CV term ID for the software is added. This is currently `"MS:-1"`, since `MSnbase` does not have its own term, but should in future be replaced with the one from `MSnbase` (See issue #321 for more info).
