### PR TITLE
Issue 325

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Depends:
     methods,
     BiocGenerics (>= 0.7.1),
     Biobase (>= 2.15.2),
-    mzR (>= 2.13.2),
+    mzR (>= 2.13.6),
     BiocParallel,
     ProtGenerics (>= 1.9.1)
 Imports:

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 # MSnbase 2.5
 
 Changes in version 2.5.10
+- Centroiding information is retrieved from raw files (for mzML/mzXML files; 
+  see issue #325) <2018-03-26>
 - Rewrite `utils.removePeaks` and remove `IRanges` dependency (see PR #320) <2018-03-21>
 
 Changes in version 2.5.9

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,9 @@
 Changes in version 2.5.10
 - Adapt `utils.removePeaks` to new `IRanges` implementation; thanks to H. Pagès
   for the implementation (see PR #320 for discussion) <2018-03-26>.
-
+- Centroiding information is retrieved from raw files (for mzML/mzXML files;.
+  see issue #325 <2018-03-27>
+  
 Changes in version 2.5.9
 - New combineSpectra, combineSpectraMovingWindow, estimateMzScattering and
   estimateMzResulution functions <2018-03-05>.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Changes in version 2.5.10
 - Adapt `utils.removePeaks` to new `IRanges` implementation; thanks to H. Pagès
   for the implementation (see PR [#320](https://github.com/lgatto/MSnbase/issues/320) for discussion) <2018-03-26>.
+- Centroiding information is retrieved from raw files (for mzML/mzXML files;.
+  see issue [#325](https://github.com/lgatto/MSnbase/issues/325) <2018-03-27>
 
 ## Changes in version 2.5.9
 - New combineSpectra, combineSpectraMovingWindow, estimateMzScattering and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # MSnbase 2.5
 
 ## Changes in version 2.5.10
+- Centroiding information is retrieved from raw files (for mzML/mzXML files; 
+  see issue [#325](https://github.com/lgatto/MSnbase/issues/325) <2018-03-26>
 - Rewrite `utils.removePeaks` and remove `IRanges` dependency (see PR [#320](https://github.com/lgatto/MSnbase/issues/320)) <2018-03-21>
 
 ## Changes in version 2.5.9

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -547,6 +547,7 @@ validSpectrum <- function(object) {
 #' - mergedResultStartScanNum
 #' - mergedResultEndScanNum
 #' - injectionTime
+#' - centroided
 #' 
 #' @author Johannes Rainer
 #'
@@ -574,7 +575,8 @@ validSpectrum <- function(object) {
              mergedResultScanNum = 0,   # ???
              mergedResultStartScanNum = 0, # ???
              mergedResultEndScanNum = 0,   # ???
-             injectionTime = 0            # Don't have that
+             injectionTime = 0,            # Don't have that
+             centroided = centroided(x)
              )
     if (msLevel(x) > 1) {
         res["collisionEnergy"] <- collisionEnergy(x)

--- a/R/methods-write.R
+++ b/R/methods-write.R
@@ -2,33 +2,43 @@
 #'
 #' @aliases writeMSData
 #' 
-#' @description The `writeMSData,MSnExp` and `writeMSData,OnDiskMSnExp` saves
-#'     the content of a [MSnExp] or [OnDiskMSnExp] object to MS file(s) in
-#'     either *mzML* or *mzXML* format.
+#' @description
 #'
-#' @details The `writeMSData` method uses the *proteowizard* libraries through
-#'     the `mzR` package to save the MS data. The data can be written to
-#'     *mzML* or *mzXML* files with or without copying additional metadata
-#'     information from the original files from which the data was read by the
-#'     [readMSData()] function. This can be set using the `copy` parameter.
-#'     Note that `copy = TRUE` requires the original files to be available and
-#'     is not supported for input files in other than mzML or mzXML format.
-#'     All metadata related to the run is copied, such as instrument
-#'     information, data processings etc. If `copy = FALSE` only processing
-#'     information performed in R (using `MSnbase`) are saved to the mzML file.
+#' The `writeMSData,MSnExp` and `writeMSData,OnDiskMSnExp` saves
+#' the content of a [MSnExp] or [OnDiskMSnExp] object to MS file(s) in
+#' either *mzML* or *mzXML* format.
 #'
-#'     Currently only spectrum data is supported, i.e. if the original mzML
-#'     file contains also chromatogram data it is not copied/saved to the new
-#'     mzML file.
+#' @details
 #'
-#' @note General spectrum data such as total ion current, peak count, base peak
-#'     m/z or base peak intensity are calculated from the actual spectrum data
-#'     before writing the data to the files.
+#' The `writeMSData` method uses the *proteowizard* libraries through
+#' the `mzR` package to save the MS data. The data can be written to
+#' *mzML* or *mzXML* files with or without copying additional metadata
+#' information from the original files from which the data was read by the
+#' [readMSData()] function. This can be set using the `copy` parameter.
+#' Note that `copy = TRUE` requires the original files to be available and
+#' is not supported for input files in other than mzML or mzXML format.
+#' All metadata related to the run is copied, such as instrument
+#' information, data processings etc. If `copy = FALSE` only processing
+#' information performed in R (using `MSnbase`) are saved to the mzML file.
 #'
-#'     For MSn data, if the `OnDiskMSnExp` or `MSnExp` does not contain also
-#'     the precursor scan of a MS level > 1 spectrum (e.g. due to filtering on
-#'     the MS level) `precursorScanNum` is set to 0 in the output file to
-#'     avoid potentially linking to a wrong spectrum.
+#' Currently only spectrum data is supported, i.e. if the original mzML
+#' file contains also chromatogram data it is not copied/saved to the new
+#' mzML file.
+#'
+#' @note
+#'
+#' General spectrum data such as total ion current, peak count, base peak
+#' m/z or base peak intensity are calculated from the actual spectrum data
+#' before writing the data to the files.
+#'
+#' For MSn data, if the `OnDiskMSnExp` or `MSnExp` does not contain also
+#' the precursor scan of a MS level > 1 spectrum (e.g. due to filtering on
+#' the MS level) `precursorScanNum` is set to 0 in the output file to
+#' avoid potentially linking to a wrong spectrum.
+#'
+#' The exported `mzML` file *should* be valid according to the mzML 1.1.2
+#' standard. For exported `mzXML` files it can not be guaranteed that they
+#' are valid and can be opened with other software than `mzR`/`MSnbase`.
 #' 
 #' @param object `OnDiskMSnExp` or `MSnExp` object.
 #'

--- a/R/readMSData.R
+++ b/R/readMSData.R
@@ -32,10 +32,12 @@
 ##' @param verbose Verbosity flag. Default is to use
 ##'     [isMSnbaseVerbose()].
 ##' @param centroided. A `logical`, indicating whether spectra are
-##'     centroided or not. Default is `NA`. In `onDisk`, it can also
-##'     be set for different MS levels by a vector of logicals, where
-##'     the first element is for MS1, the second element is for MS2,
-##'     ... See [OnDiskMSnExp-class] for an example.
+##'     centroided or not. Default is `NA` in which case the information
+##'     is extracted from the raw file (for mzML or mzXML files). In
+##'     `onDisk`, it can also be set for different MS levels by a
+##'     vector of logicals, where the first element is for MS1, the
+##'     second element is for MS2, ... See [OnDiskMSnExp-class] for
+##'     an example.
 ##' @param smoothed. A `logical` indicating whether spectra already
 ##'     smoothed or not. Default is `NA`.
 ##' @param cache. Numeric indicating caching level. Default is 0 for
@@ -111,6 +113,10 @@ readInMemMSData <- function(files, pdata, msLevel., verbose,
         msdata <- .openMSfile(f)
         .instrumentInfo <- c(.instrumentInfo, list(instrumentInfo(msdata)))
         fullhd <- mzR::header(msdata)
+        ## Issue #325: get centroided information from file, but overwrite if
+        ## specified with centroided. parameter.
+        if (!is.na(centroided.))
+            fullhd$centroided <- as.logical(centroided.)
         spidx <- which(fullhd$msLevel == msLevel.)
         ## increase vectors as needed
         ioncount <- c(ioncount, numeric(length(spidx)))
@@ -142,7 +148,7 @@ readInMemMSData <- function(files, pdata, msLevel., verbose,
                           mz = .p[, 1],
                           intensity = .p[, 2],
                           fromFile = as.integer(filen),
-                          centroided = as.logical(centroided.),
+                          centroided = as.logical(hd$centroided),
                           smoothed = as.logical(smoothed.),
                           polarity = as.integer(pol))
                 ## peaksCount
@@ -188,7 +194,7 @@ readInMemMSData <- function(files, pdata, msLevel., verbose,
                           mz = .p[, 1],
                           intensity = .p[, 2],
                           fromFile = as.integer(filen),
-                          centroided = as.logical(centroided.),
+                          centroided = as.logical(hd$centroided),
                           smoothed = as.logical(smoothed.),
                           polarity = as.integer(hd$polarity))
                 ## peaksCount

--- a/R/readMSData2.R
+++ b/R/readMSData2.R
@@ -17,6 +17,7 @@ readMSData2 <- function(files,
 readOnDiskMSData <- function(files, pdata, msLevel., verbose,
                              centroided., smoothed.) {
     .testReadMSDataInput(environment())
+    stopifnot(is.logical(centroided.))
     ## Creating environment with Spectra objects
     assaydata <- new.env(parent = emptyenv())
     filenams <- filenums <- c()
@@ -47,10 +48,10 @@ readOnDiskMSData <- function(files, pdata, msLevel., verbose,
         ## Don't read the individual spectra, just define the names of
         ## the spectra.
         fullhdorder <- c(fullhdorder,
-                          formatFileSpectrumNames(fileIds=filen,
-                                                  spectrumIds=seq_along(spidx),
-                                                  nSpectra=length(spidx),
-                                                  nFiles=length(files)))
+                         formatFileSpectrumNames(fileIds=filen,
+                                                 spectrumIds=seq_along(spidx),
+                                                 nSpectra=length(spidx),
+                                                 nFiles=length(files)))
         ## Extract all Spectrum info from the header and put it into the featureData
         fdData <- fullhd[spidx, , drop = FALSE]
         ## rename totIonCurrent and peaksCount, as detailed in
@@ -59,10 +60,8 @@ readOnDiskMSData <- function(files, pdata, msLevel., verbose,
         ## Add also:
         ## o fileIdx -> links to fileNames property
         ## o spIdx -> the index of the spectrum in the file.
-        ## o centroided and smoothed are parameter argument.
         fdData <- cbind(fileIdx = rep(filen, nrow(fdData)),
                         spIdx = spidx,
-                        centroided = rep(NA, nrow(fdData)),
                         smoothed = rep(as.logical(smoothed.), nrow(fdData)),
                         fdData, stringsAsFactors = FALSE)
         if (isCdfFile(f)) {
@@ -150,8 +149,7 @@ readOnDiskMSData <- function(files, pdata, msLevel., verbose,
         msLevel. <- as.integer(msLevel.)
         res <- filterMsLevel(res, msLevel.)
     }
-    if (!is.null(centroided.)) {
-        stopifnot(is.logical(centroided.))
+    if (any(!is.na(centroided.))) {
         if (length(centroided.) == 1) {
             centroided(res) <- centroided.
         } else {

--- a/R/writeMSData.R
+++ b/R/writeMSData.R
@@ -146,7 +146,7 @@
     ## issue #321: replace MS:-1 with the MS CV Term of MSnbase, once it's
     ## included.
     msnbase_proc <- c("MSnbase", paste0(packageVersion("MSnbase"),
-                                        collapse = "."), "MS:-1")
+                                        collapse = "."), "MS:1002870")
     processings <- processingData(x)@processing
     if (length(processings)) {
         proc_cv <- unlist(lapply(processings, FUN = .pattern_to_cv))

--- a/R/writeMSData.R
+++ b/R/writeMSData.R
@@ -108,6 +108,8 @@
     ## mzML files will otherwise fail.
     if (!any(colnames(hdr) == "filterString"))
         hdr$filterString <- NA_character_
+    ## centroided has to be logical
+    hdr$centroided <- as.logical(hdr$centroided)
     ## o add processing steps.
     soft_proc <- .guessSoftwareProcessing(msData, software_processing)
     if (copy) {

--- a/man/readMSData.Rd
+++ b/man/readMSData.Rd
@@ -26,10 +26,12 @@ data.}
 \code{\link[=isMSnbaseVerbose]{isMSnbaseVerbose()}}.}
 
 \item{centroided.}{A \code{logical}, indicating whether spectra are
-centroided or not. Default is \code{NA}. In \code{onDisk}, it can also
-be set for different MS levels by a vector of logicals, where
-the first element is for MS1, the second element is for MS2,
-... See \linkS4class{OnDiskMSnExp} for an example.}
+centroided or not. Default is \code{NA} in which case the information
+is extracted from the raw file (for mzML or mzXML files). In
+\code{onDisk}, it can also be set for different MS levels by a
+vector of logicals, where the first element is for MS1, the
+second element is for MS2, ... See \linkS4class{OnDiskMSnExp} for
+an example.}
 
 \item{smoothed.}{A \code{logical} indicating whether spectra already
 smoothed or not. Default is \code{NA}.}

--- a/man/writeMSData.Rd
+++ b/man/writeMSData.Rd
@@ -48,19 +48,25 @@ Note that \code{copy = TRUE} requires the original files to be available and
 is not supported for input files in other than mzML or mzXML format.
 All metadata related to the run is copied, such as instrument
 information, data processings etc. If \code{copy = FALSE} only processing
-information performed in R (using \code{MSnbase}) are saved to the mzML file.\preformatted{Currently only spectrum data is supported, i.e. if the original mzML
+information performed in R (using \code{MSnbase}) are saved to the mzML file.
+
+Currently only spectrum data is supported, i.e. if the original mzML
 file contains also chromatogram data it is not copied/saved to the new
 mzML file.
-}
 }
 \note{
 General spectrum data such as total ion current, peak count, base peak
 m/z or base peak intensity are calculated from the actual spectrum data
-before writing the data to the files.\preformatted{For MSn data, if the `OnDiskMSnExp` or `MSnExp` does not contain also
+before writing the data to the files.
+
+For MSn data, if the \code{OnDiskMSnExp} or \code{MSnExp} does not contain also
 the precursor scan of a MS level > 1 spectrum (e.g. due to filtering on
-the MS level) `precursorScanNum` is set to 0 in the output file to
+the MS level) \code{precursorScanNum} is set to 0 in the output file to
 avoid potentially linking to a wrong spectrum.
-}
+
+The exported \code{mzML} file \emph{should} be valid according to the mzML 1.1.2
+standard. For exported \code{mzXML} files it can not be guaranteed that they
+are valid and can be opened with other software than \code{mzR}/\code{MSnbase}.
 }
 \author{
 Johannes Rainer

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -395,8 +395,8 @@ test_that("injection time", {
     f <- msdata::proteomics(full.names = TRUE,
                             pattern = "MS3TMT10_01022016_32917-33481.mzML.gz")
     it1 <- MSnbase:::injectionTimeFromFile1(f) ## in millisecs
-    it2 <- fData(readMSData(f, mode = "onDisk"))$injectionTime ## in secs
-    expect_equal(it1/1000, it2)
+    it2 <- fData(readMSData(f, mode = "onDisk"))$injectionTime ## in millisecs
+    expect_equal(it1, it2)
 })
 
 test_that("chromatogram,MSnExp works", {

--- a/tests/testthat/test_centroided.R
+++ b/tests/testthat/test_centroided.R
@@ -2,19 +2,15 @@ test_that("centroided accessor with/without na.fail", {
     x <- tmt_erwinia_in_mem_ms2
     x2 <- tmt_erwinia_on_disk
     ## in-mem, single spectrum
-    expect_true(is.na(centroided(x[[1]])))
-    expect_error(centroided(x[[1]], na.fail = TRUE))
+    expect_true(centroided(x[[1]]))
     ## in-mem, experiment
-    expect_true(all(is.na(centroided(x))))
-    expect_error(centroided(x, na.fail = TRUE))
+    expect_true(all(centroided(x)))
     ## on-disk, single spectrum
-    expect_true(is.na(centroided(x2[[1]])))
-    expect_error(centroided(x2[[1]], na.fail = TRUE))
+    expect_true(!centroided(x2[[1]]))
+    expect_true(centroided(x2[[2]]))
     ## on-disk, experiment
-    expect_true(all(is.na(centroided(x2))))
-    expect_error(centroided(x2, na.fail = TRUE))
-    fData(x2)$centroided[1:(length(x2) - 1)] <- TRUE
-    expect_error(centroided(x2, na.fail = TRUE))
+    expect_true(all(!centroided(filterMsLevel(x2, 1))))
+    expect_true(all(centroided(filterMsLevel(x2, 2))))
 })
 
 

--- a/tests/testthat/test_readMSData2.R
+++ b/tests/testthat/test_readMSData2.R
@@ -4,16 +4,25 @@ test_that("msLevel set correctly", {
     f <- msdata::proteomics(full.names = TRUE,
                             pattern = "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzML.gz")
     x <- readMSData(f, verbose = FALSE, mode = "onDisk")
-    expect_equivalent(centroided(x), rep(NA, length(x)))
+    ms1 <- filterMsLevel(x, msLevel = 1)
+    ms2 <- filterMsLevel(x, msLevel = 2)
+    expect_true(all(!centroided(ms1)))
+    expect_true(all(centroided(ms2)))
     x <- readMSData(f, centroided = TRUE, verbose = FALSE, mode = "onDisk")
-    expect_equivalent(centroided(x), rep(TRUE, length(x)))
+    expect_true(all(centroided(x)))
     x <- readMSData(f, centroided = FALSE, verbose = FALSE, mode = "onDisk")
-    expect_equivalent(centroided(x), rep(FALSE, length(x)))
+    expect_true(all(!centroided(x)))
     x <- readMSData(f, centroided = c(FALSE, TRUE), verbose = FALSE, mode = "onDisk")
     expect_true(all(centroided(filterMsLevel(x, msLevel = 2))))
     expect_true(all(!centroided(filterMsLevel(x, msLevel = 1))))    
     x2 <- readMSData(f, centroided = c(FALSE, TRUE, NA, NA), verbose = FALSE, mode = "onDisk")
     expect_identical(centroided(x), centroided(x2))
+    ## In mem with centroided.
+    f <- system.file("microtofq/MM14.mzML", package = "msdata")
+    x <- readMSData(f, msLevel = 1)
+    expect_true(all(centroided(x)))
+    x <- readMSData(f, msLevel = 1, centroided = FALSE)
+    expect_true(all(!centroided(x)))
 })
 
 ############################################################

--- a/tests/testthat/test_writeMSData.R
+++ b/tests/testthat/test_writeMSData.R
@@ -1,4 +1,8 @@
 test_that("writeMSData works", {
+    mzML_xsd_idx <- XML::xmlTreeParse(system.file("extdata", "mzML1.1.2_idx.xsd",
+                                                  package = "mzR"),
+                                      isSchema = TRUE, useInternal = TRUE)
+
     ## using the onDisk data.
     odf <- tmt_erwinia_on_disk
     ## 1) Filter MS level 1, write, read and compare with tmt_erwinia_in_mem_ms1
@@ -6,6 +10,10 @@ test_that("writeMSData works", {
     out_file <- paste0(tempfile(), ".mzML")
     MSnbase:::.writeSingleMSData(odf_out, file = out_file,
                                  outformat = "mzml", copy = TRUE)
+    ## Validating the mzML file
+    doc <- XML::xmlInternalTreeParse(out_file)
+    res <- XML::xmlSchemaValidate(mzML_xsd_idx, doc)
+    expect_equal(res$status, 0)
     odf_in <- readMSData(out_file, mode = "onDisk")
     ## Some stuff is different, i.e. totIonCurrent, basePeakMZ, basePeakIntensity
     expect_equal(unname(rtime(odf_in)), unname(rtime(tmt_erwinia_in_mem_ms1)))
@@ -66,6 +74,13 @@ test_that("writeMSData works", {
     out_file <- paste0(out_path, c("/a.mzML", "/b.mzML"))
     MSnbase:::.writeMSData(microtofq_on_disk_ms1, file = out_file,
                            copy = FALSE)
+    ## Validating the mzML file
+    doc <- XML::xmlInternalTreeParse(out_file[1])
+    res <- XML::xmlSchemaValidate(mzML_xsd_idx, doc)
+    expect_equal(res$status, 0)
+    doc <- XML::xmlInternalTreeParse(out_file[2])
+    res <- XML::xmlSchemaValidate(mzML_xsd_idx, doc)
+    expect_equal(res$status, 0)    
     odf_in <- readMSData(out_file, mode = "onDisk")
     expect_equal(unname(rtime(odf_in)), unname(rtime(microtofq_in_mem_ms1)))
     expect_equal(spectra(odf_in), spectra(microtofq_in_mem_ms1))
@@ -78,6 +93,7 @@ test_that("writeMSData works", {
     expect_equal(unname(rtime(odf)), unname(rtime(odf_in)))
     expect_equal(unname(mz(odf)), unname(mz(odf_in)))
     expect_equal(unname(intensity(odf)), unname(intensity(odf_in)))
+
 })
 
 test_that(".pattern_to_cv works", {

--- a/tests/testthat/test_writeMSData.R
+++ b/tests/testthat/test_writeMSData.R
@@ -111,7 +111,7 @@ test_that(".guessSoftwareProcessing works", {
     res <- .guessSoftwareProcessing(odf_proc)
     expect_equal(res[[1]][1], "MSnbase")
     expect_equal(res[[1]][2], paste0(packageVersion("MSnbase"), collapse = "."))
-    expect_equal(res[[1]][3], "MS:-1")
+    expect_equal(res[[1]][3], "MS:1002870")
     expect_equal(res[[1]][4], "MS:1001486")
     ## clean: Spectra cleaned NO CV YET
     ## bin: Spectra binned: NO CV YET


### PR DESCRIPTION
This ensures `MSnbase` works with the recent changes in `mzR` (2.13.6):
+ centroided information is extracted from `mzML` and `mzXML` files.
+ MS CV Term ID of `MSnbase` is written to exported `mzML` files.
+ Unit tests are accordingly adapted including a test to validate generated `mzML` files.