### PR TITLE
Fix bug in `robustSummary()`

### DIFF
--- a/R/combineFeatures.R
+++ b/R/combineFeatures.R
@@ -321,10 +321,10 @@ robustSummary <- function(e, residuals = FALSE, ...) {
     ## This will be needed for NUSE-type of quality control, but will
     ## need to check for missing data as below.
     ## se <- unique(summary(fit)$coefficients[sampleid, 'Std. Error'])
-
-    ## Put NA for the samples without any expression value
-    present <- as.logical(colSums(p))
-    res <- rep(NA, length(present))
-    res[present] <- fit$coefficients[sampleid]
-    res
+  
+    ## Take the sample coefficients ( = summarised expression values)
+    coef = fit$coefficients[sampleid]
+    ## Sort the sample coefficients in the same way as the samplenames of expression matrix
+    ## Puts NA for the samples without any expression value  
+    coef[paste0('sample',colnames(e))]
 }


### PR DESCRIPTION
When samplenames of input are not alphabetically ordered, the order of the `robustSummary()` output is incorrect.

Model.matrix orders the ellements in a categorical variable alphabetically.
So the coefficients of rlm are also ordered alphabetically.
This order should be again reversed in the output into the same order as the samplesnames of input.

The proposed code change fixes this.