### PR TITLE
Internal MGF export functions gain parameter addFields

### DIFF
--- a/R/readWriteMgfData.R
+++ b/R/readWriteMgfData.R
@@ -34,7 +34,8 @@ writeMgfDataFile <- function(splist, con, COM = NULL, TITLE = NULL,
   if (length(addFields)) {
       if (length(dim(addFields)) != 2)
           stop("'addFields' has to be a matrix or data.frame.")
-      else addFields <- as.matrix(addFields, ncol = ncol(addFields))
+      if (!is.matrix(addFields))
+          addFields <- do.call(cbind, lapply(addFields, as.character))
       if (is.null(colnames(addFields)))
           stop("Column names required on 'addFields'.")
       if (nrow(addFields) != length(splist))

--- a/R/readWriteMgfData.R
+++ b/R/readWriteMgfData.R
@@ -32,15 +32,14 @@ writeMgfDataFile <- function(splist, con, COM = NULL, TITLE = NULL,
   }
 
   if (length(addFields)) {
-      if (is.null(dim(addFields)))
+      if (length(dim(addFields)) != 2)
           stop("'addFields' has to be a matrix or data.frame.")
       else addFields <- as.matrix(addFields, ncol = ncol(addFields))
       if (is.null(colnames(addFields)))
           stop("Column names required on 'addFields'.")
       if (nrow(addFields) != length(splist))
           stop("nrow of 'addFields' has to match length of 'splist'")
-      haveAddFields <- TRUE
-  } else haveAddFields <- FALSE
+  }
 
   con <- file(description = con, open = "at")
   on.exit(close(con))
@@ -60,17 +59,14 @@ writeMgfDataFile <- function(splist, con, COM = NULL, TITLE = NULL,
     if (verbose)
       setTxtProgressBar(pb, i)
 
-    if (haveAddFields)
-        writeMgfContent(splist[[i]], TITLE = NULL, con = con,
+    writeMgfContent(splist[[i]], TITLE = TITLE, con = con,
                         addFields = addFields[i, ])
-    else
-        writeMgfContent(splist[[i]], TITLE = NULL, con = con)
   }
   if (verbose)
     close(pb)
 }
 
-writeMgfContent <- function(sp, TITLE = NULL, con, addFields = TRUE) {
+writeMgfContent <- function(sp, TITLE = NULL, con, addFields = NULL) {
     .cat <- function(..., file = con, sep = "", append = TRUE) {
         cat(..., file = file, sep = sep, append = append)
     }
@@ -102,11 +98,9 @@ writeMgfContent <- function(sp, TITLE = NULL, con, addFields = TRUE) {
         }
     } else .cat("\nRTINSECONDS=", rtime(sp))
 
-    if (length(addFields)) {
-        if (!is.null(names(addFields)))
-            .cat(paste0("\n", paste(toupper(names(addFields)),
-                                    addFields, sep = "="), collapse = ""))
-    }
+    if (length(addFields) && !is.null(names(addFields)))
+        .cat("\n", paste(toupper(names(addFields)),
+                         addFields, sep = "=", collapse = "\n"))
 
     .cat("\n", paste(mz(sp), intensity(sp), collapse = "\n"))
     .cat("\nEND IONS\n")

--- a/tests/testthat/test_readWriteMgfData.R
+++ b/tests/testthat/test_readWriteMgfData.R
@@ -32,3 +32,81 @@ test_that("extractMgfSpectrum2Info", {
   expect_equal(MSnbase:::extractMgfSpectrum2Info(mgf, centroided = TRUE),
                result)
 })
+
+test_that("writeMgfContent works", {
+    s <- new("Spectrum2",
+             rt = 600,
+             scanIndex = 0L,
+             precursorMz = 100,
+             precursorIntensity = 50000,
+             precursorCharge = 3L,
+             mz = c(10, 11, 12, 13),
+             intensity = c(100, 200, 300, 400),
+             fromFile = 1L,
+             acquisitionNum = NA_integer_,
+             collisionEnergy = NA_real_,
+             precScanNum = NA_integer_,
+             centroided = TRUE)
+    tmpf <- tempfile()
+    MSnbase:::writeMgfContent(s, con = tmpf)
+    lns <- readLines(tmpf)
+    expect_equal(lns[grep("^RT", lns)], "RTINSECONDS=600")
+    expect_equal(lns[8], "10 100")
+    res <- readMgfData(tmpf)
+    expect_equal(mz(res[[1]]), mz(s))
+    
+    file.remove(tmpf)
+    MSnbase:::writeMgfContent(s, con = tmpf, addFields = c(ID = 12))
+    lns <- readLines(tmpf)
+    expect_equal(lns[8], "ID=12")
+
+    file.remove(tmpf)
+    MSnbase:::writeMgfContent(s, con = tmpf, addFields = c(ID = 12,
+                                                           feature = "B"))
+    lns <- readLines(tmpf)
+    expect_equal(lns[8], "ID=12")
+    expect_equal(lns[9], "FEATURE=B")
+
+    res <- readMgfData(tmpf)
+    expect_equal(mz(res[[1]]), mz(s))
+    expect_equal(intensity(res[[1]]), intensity(s))
+})
+
+test_that("writeMgfDataFile works", {
+
+    s1 <- new("Spectrum2",
+             rt = 600,
+             scanIndex = 0L,
+             precursorMz = 100,
+             precursorIntensity = 50000,
+             precursorCharge = 3L,
+             mz = c(10, 11, 12, 13),
+             intensity = c(100, 200, 300, 400),
+             fromFile = 1L,
+             acquisitionNum = NA_integer_,
+             collisionEnergy = NA_real_,
+             precScanNum = NA_integer_,
+             centroided = TRUE)
+    s2 <- new("Spectrum2",
+              rt = 601, mz = c(12, 13, 14, 15, 16),
+              intensity = c(200, 3000, 4000, 300, 399),
+              fromFile = 2L)
+
+    tmpf <- tempfile()
+    MSnbase:::writeMgfDataFile(list(s1, s2), tmpf)
+    lns <- readLines(tmpf)
+    
+    ## With addFields
+    file.remove(tmpf)
+    af <- data.frame(pkid = c("a", "b"), value = 1:2)
+
+    expect_error(MSnbase:::writeMgfDataFile(list(s1, s2), tmpf, addFields = 3))
+    expect_error(MSnbase:::writeMgfDataFile(list(s1, s2), tmpf,
+                                            addFields = af[1, ]))
+    MSnbase:::writeMgfDataFile(list(s1, s2), tmpf, addFields = af)
+    lns <- readLines(tmpf)
+    expect_equal(lns[8], "PKID=a")
+    expect_equal(lns[9], "VALUE=1")
+    expect_equal(lns[21], "PKID=b")
+    expect_equal(lns[22], "VALUE=2")
+})


### PR DESCRIPTION
Add parameter addFields to internal writeMgfDataFile and writeMgfContent to support addition of arbitrary additional fields in the MGF output file.
