### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/functions-fragments.R
+++ b/R/functions-fragments.R
@@ -36,7 +36,7 @@
   ## decomposition in a tandem mass spectrometer: differentiation of leucine
   ## and isoleucine.
   ## Analytical Chemistry, 59(21), 2621-2625.
-  ## http://dx.doi.org/10.1021/ac00148a019
+  ## https://doi.org/10.1021/ac00148a019
   ##
   ## a proton (H+) is added later
   ## (after calculation of the different charge states)

--- a/R/matching.R
+++ b/R/matching.R
@@ -105,14 +105,14 @@ numberOfCommonPeaks <- function(x, y, tolerance=25e-6, relative=TRUE) {
 #' Optimization and testing of mass spectral library search algorithms for
 #' compound identification.
 #' Journal of the American Society for Mass Spectrometry, 5(9), 859-866.
-#' doi: http://dx.doi.org/10.1016/1044-0305(94)87009-8
+#' doi: https://doi.org/10.1016/1044-0305(94)87009-8
 #'
 #' Lam, H., Deutsch, E. W., Eddes, J. S., Eng, J. K., King, N., Stein, S. E.
 #' and Aebersold, R. (2007)
 #' Development and validation of a spectral library searching method for peptide
 #' identification from MS/MS.
 #' Proteomics, 7: 655-667.
-#' doi: http://dx.doi.org/10.1002/pmic.200600625
+#' doi: https://doi.org/10.1002/pmic.200600625
 #'
 #' @param x double
 #' @param y double

--- a/docs/reference/compareSpectra-methods.html
+++ b/docs/reference/compareSpectra-methods.html
@@ -194,13 +194,13 @@ Instead of these three predefined functions for fun a
   Optimization and testing of mass spectral library search algorithms for
   compound identification.
   Journal of the American Society for Mass Spectrometry, 5(9), 859-866.
-  doi: http://dx.doi.org/10.1016/1044-0305(94)87009-8</p>
+  doi: https://doi.org/10.1016/1044-0305(94)87009-8</p>
 <p>Lam, H., Deutsch, E. W., Eddes, J. S., Eng, J. K., King, N., Stein, S. E.
   and Aebersold, R. (2007)
   Development and validation of a spectral library searching method for peptide
   identification from MS/MS.
   Proteomics, 7: 655-667.
-  doi: http://dx.doi.org/10.1002/pmic.200600625</p>
+  doi: https://doi.org/10.1002/pmic.200600625</p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>

--- a/man/compareSpectra-methods.Rd
+++ b/man/compareSpectra-methods.Rd
@@ -63,14 +63,14 @@
   Optimization and testing of mass spectral library search algorithms for
   compound identification.
   Journal of the American Society for Mass Spectrometry, 5(9), 859-866.
-  doi: http://dx.doi.org/10.1016/1044-0305(94)87009-8
+  doi: https://doi.org/10.1016/1044-0305(94)87009-8
 
   Lam, H., Deutsch, E. W., Eddes, J. S., Eng, J. K., King, N., Stein, S. E.
   and Aebersold, R. (2007)
   Development and validation of a spectral library searching method for peptide
   identification from MS/MS.
   Proteomics, 7: 655-667.
-  doi: http://dx.doi.org/10.1002/pmic.200600625
+  doi: https://doi.org/10.1002/pmic.200600625
 }
 
 \examples{

--- a/vignettes/MSnbase.bib
+++ b/vignettes/MSnbase.bib
@@ -30,7 +30,7 @@
 	Pii = {gb-2004-5-10-r80},
 	Pmid = {15461798},
 	Timestamp = {2006.09.27},
-	Url = {http://dx.doi.org/10.1186/gb-2004-5-10-r80},
+	Url = {https://doi.org/10.1186/gb-2004-5-10-r80},
 	author = {Gentleman, Robert C. and Carey, Vincent J. and
 		  Bates, Douglas M. and Bolstad, Ben and Dettling,
 		  Marcel and Dudoit, Sandrine and Ellis, Byron and
@@ -124,7 +124,7 @@
 	Pii = {nbt1329},
 	Pmid = {17687369},
 	Timestamp = {2010.02.03},
-	Url = {http://dx.doi.org/10.1038/nbt1329},
+	Url = {https://doi.org/10.1038/nbt1329},
 	author = {Taylor, Chris F. and Paton, Norman W. and Lilley,
 		  Kathryn S. and Binz, Pierre-Alain and Julian,
 		  Randall K. and Jones, Andrew R. and Zhu, Weimin and
@@ -183,7 +183,7 @@
 	Pii = {M400129-MCP200},
 	Pmid = {15385600},
 	Timestamp = {2010.01.27},
-	Url = {http://dx.doi.org/10.1074/mcp.M400129-MCP200},
+	Url = {https://doi.org/10.1074/mcp.M400129-MCP200},
 	author = {Ross, Philip L. and Huang, Yulin N. and Marchese,
 		  Jason N. and Williamson, Brian and Parker, Kenneth
 		  and Hattan, Stephen and Khainovski, Nikita and


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!