### PR TITLE
Split dependency building and pkg checking on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,7 @@ jobs:
 # In general the r-travis script automatically dump the logs after failure but
 # because of a bug in travis the output is often truncated. See
 # https://github.com/travis-ci/travis-ci/issues/6018
-# (Adding `sleep 10` in after_script as proposed by some people didn't work for
-# me.)
-after_failure: dump_error_logs
+after_failure: sleep 10
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,57 @@
+# full script at https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/r.rb
 language: r
 r: bioc-devel
+bioc_check: true
 cache: packages
-sudo: false       # use container based build system
+sudo: required
 warnings_are_errors: true
 dist: trusty
 
-# Set CXX1X for R-devel, as R-devel does not detect CXX1X support for gcc 4.6.3,
-# this was causing mzR installation to fail
-# see https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17189
-# workaround stolen from https://github.com/hadley/devtools/blob/1ce84b04568ff7846c3da754f28e7e22a23c8737/.travis.yml#L23-L26
-before_install:
-  - if [[ "$TRAVIS_R_VERSION_STRING" = 'bioc-devel' ]]; then mkdir ~/.R && echo 'CXX1X=g++ -std=c++0x -g -O2 -fPIC' > ~/.R/Makevars; fi
-
+# unfortunately apt packages are not cached
+# we could use these build dependencies just in the "Build" stage and
+# install their runtime libraries counter parts in "Check" but that would make
+# the script more complicated and saves just a few seconds
 addons:
   apt:
     packages:
       - libnetcdf-dev
-      - netcdf-bin # libnetcdf-dev doesn't contain nc-config in ubuntu 12.04 (in 16.04 it is part of libnetcdf-dev)
+      - netcdf-bin # libnetcdf-dev doesn't contain nc-config in ubuntu 12.04 (in 16.04 [xerus] it is part of libnetcdf-dev)
       - libhdf5-dev
+      - libgit2-dev # git2r
 
-r_packages:
-  - covr
+jobs:
+  include:
+    - stage: "Build"
+      r_packages:
+        - covr
+        - pkgdown
+        - testthat
+        - knitr
+        - roxygen2
+      before_install:
+        - mkdir -p ~/.R
+        - echo -e 'MAKEFLAGS = -j2' > ~/.R/Makevars
+        - echo 'options(Ncpus = 2)' > ~/.Rprofile
+      script: true
+      name: "Build dependencies and cache"
+    - stage: "Check"
+      install: skip
+      after_success:
+        - travis_wait 20 Rscript -e 'covr::codecov()'
+        - test ${TRAVIS_BRANCH} = "master" -a -z "${TRAVIS_PULL_REQUEST_BRANCH}" && travis_wait 20 Rscript -e 'pkgdown::build_site()'
+      name: "R CMD check"
 
-# before_script:
-#   - echo "BiocParallel::register(BiocParallel::SerialParam())" > ~/.Rprofile
-  
-script: 
-  - | 
-    R CMD build .
-    travis_wait 40 R CMD check --no-build-vignettes --no-vignettes MSnbase*tar.gz
-
-after_failure:
-  find *Rcheck -name '*.fail' -print -exec cat '{}' \;
-  
-after_success:
-  - travis_wait 20 Rscript -e 'covr::codecov()'
-
-# # print timings (of examples) and sysinfo
-# after_script:
-#   - dump_logs_by_extension "timings"
-#   - dump_sysinfo
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_PAT
+  keep-history: true
+  local-dir: docs
+  on:
+    branch: master
 
 notifications:
   email:
-    on_failure: lg390@cam.ac.uk
-
+    recipients: lg390@cam.ac.uk
+    on_failure: change
+    on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,13 @@ jobs:
         on:
           branch: master
 
+# In general the r-travis script automatically dump the logs after failure but
+# because of a bug in travis the output is often truncated. See
+# https://github.com/travis-ci/travis-ci/issues/6018
+# (Adding `sleep 10` in after_script as proposed by some people didn't work for
+# me.)
+after_failure: dump_error_logs
+
 notifications:
   email:
     recipients: lg390@cam.ac.uk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 # full script at https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/r.rb
 language: r
 r: bioc-devel
-bioc_check: true
-cache: packages
+cache:
+  packages: true
+  directories:
+    - ~/.AnnotationHub
 sudo: required
 warnings_are_errors: true
 dist: trusty
@@ -35,20 +37,34 @@ jobs:
       script: true
       name: "Build dependencies and cache"
     - stage: "Check"
+      r_build_args: --no-build-vignettes --no-manual
+      r_check_args: --as-cran --no-build-vignettes --no-vignettes --no-manual --no-tests
+      before_script: rm -rf vignettes
       install: skip
-      after_success:
+      name: "examples"
+    - r_build_args: --no-build-vignettes --no-manual
+      r_check_args: --as-cran --no-build-vignettes --no-vignettes --no-manual --no-codoc --no-examples
+      install: skip
+      before_script: rm -rf vignettes
+      name: "tests"
+    - r_build_args:
+      r_check_args: --as-cran --no-build-vignettes --no-codoc --no-examples --no-tests
+      install: skip
+      name: "vignettes"
+    - stage: "Deploy"
+      install: skip
+      script:
         - travis_wait 20 Rscript -e 'covr::codecov()'
         - test ${TRAVIS_BRANCH} = "master" -a -z "${TRAVIS_PULL_REQUEST_BRANCH}" && travis_wait 20 Rscript -e 'pkgdown::build_site()'
-      name: "R CMD check"
-
-deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_PAT
-  keep-history: true
-  local-dir: docs
-  on:
-    branch: master
+      name: "codecov and pkgdown (on master)"
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        github-token: $GITHUB_PAT
+        keep-history: true
+        local-dir: docs
+        on:
+          branch: master
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
       install: skip
       script:
         - travis_wait 20 Rscript -e 'covr::codecov()'
-        - test ${TRAVIS_BRANCH} = "master" -a -z "${TRAVIS_PULL_REQUEST_BRANCH}" && travis_wait 20 Rscript -e 'pkgdown::build_site()'
+        - if [ ${TRAVIS_BRANCH} = "master" ] && [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] ; then travis_wait 20 Rscript -e 'pkgdown::build_site()' ; fi
       name: "codecov and pkgdown (on master)"
       deploy:
         provider: pages

--- a/tests/testthat/test_MSmap.R
+++ b/tests/testthat/test_MSmap.R
@@ -1,5 +1,7 @@
 context("MSmap class")
 
+skip_on_travis()
+
 library("AnnotationHub")
 ah <- AnnotationHub()
 ms <- ah[["AH49008"]]


### PR DESCRIPTION
Currently our CI fails on travis because the hard runtime limit for jobs
is 50 minutes and installing all dependencies of MSnbase takes a lot of
more time.

<img width="674" alt="image" src="https://user-images.githubusercontent.com/1828443/47213124-6522bd80-d39a-11e8-8b36-e88be9f55a0e.png">

This commit introduces multiple changes:
- Use 2 cores for package building/installation.
- Split building of dependencies and package checking into different
  jobs which allows us to use 2x50 minutes. The build job builds all dependencies and create a cache which is used by the check job.
- Automatically deploy of `pkgdown` based documentation to github pages the master branch.

@lgatto if you want to use the automatic deployment you have to create a [**P**ersonal **A**ccess **T**oken](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with the `public_repo`  scope/permission and register it in the [travis' settings](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings) with the name `GITHUB_PAT`

We could create even more jobs to reduce the check time a little bit (currently after cache building it takes ~ 35 min to run travis but using three check jobs ("examples", "vignettes", "test") we could go down to ~ 25 min:

**2 jobs (build + check, current PR)**

<img width="624" alt="travis1" src="https://user-images.githubusercontent.com/1828443/47212494-a3b77880-d398-11e8-9e26-693cf58ac8df.png">

**5 jobs (build + 3 check + codecov)** (the codecov job failed because I accidentally used `rscript` instead of `Rscript`)

<img width="1055" alt="tavis2" src="https://user-images.githubusercontent.com/1828443/47212493-a31ee200-d398-11e8-9185-829387e0cf24.png">

@lgatto If you wish I could easily extend this PR to the version with 5 jobs.

BTW: 
- I add `skip_on_travis()` to `tests/testthat/test_MSmap.R` on my forked repository because downloading files from `AnnotationHub` always failed (maybe we should consider it to add it here, too).
- `MSnbase` needs more than 250 packages to build. Maybe we could remove a few, e.g. `shiny` is just used for one function (could `selectFeatureData` move to `pRolocGUI`?), same for `XML` which is just used by `.isCentroidedFromFile` and `mzID` both could be replaced by `mzR`/`xml2` (the latter is downloaded anyway by other dependencies), `affy`/`affyio` just for `MAplot`, `gplots` just for `heatmap.2` in the vignette, ... it is somehow connected to #201 but would just improve the build time. Should we open an issue and try to remove some build dependencies or just keep status quo?