### PR TITLE
Add .editorconfig

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,8 +1,9 @@
-.travis.yml
+.editorconfig
 .gitignore
 .gitignores
-Makefile
-README.Rmd
-NEWS.md
+.travis.yml
 docs
 ^docs$
+Makefile
+NEWS.md
+README.Rmd

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.R]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[Makefile]
+indent_style = tab
+
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This PR is just a suggestion, so fell free to close without merging.

It adds a `.editorconfig` file to the repository. [EditorConfig](https://editorconfig.org/) is a platform and **editor**-independent way of defining editor settings/code styles for different files, e.g. tab instead of spaces, indentation by 4 spaces, line ending, ...

I often have the problem that my `nvim` removes spaces at the end of lines (and it seems that your emacs doesn't do this) which obscure my commits. In general I use `git add -p` and just select the lines where the content really changed, ignoring spaces (sometimes I forget this but I can't find a commit that is showing this, yet). Also different settings of indentation can result in errors, e.g.: https://github.com/lgatto/pRoloc/commit/0be04a3 (https://travis-ci.org/lgatto/pRoloc/requests)

More information:
- EditorConfig website: https://editorconfig.org
- Supported settings: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties

Each develop needs to install the `editorconfig` C program (debian: `apt-get install editorconfig`) and the editor-specific plugin:
- emacs: https://github.com/editorconfig/editorconfig-emacs#readme
- (n)vim: https://github.com/editorconfig/editorconfig-vim#readme
- github (if you edit/look files in the browser) has native editorconfig support.

@lgatto, @jotsetung what do you think?

EDIT: `editorconfig` is a program written in C not in python.