### PR TITLE
Fix [,Chromatograms to support classes extending Chromatograms

### DIFF
--- a/R/functions-Chromatogram.R
+++ b/R/functions-Chromatogram.R
@@ -94,7 +94,7 @@ names(.SUPPORTED_AGG_FUN_CHROM) <-
 #' @param msLevel \code{integer} with the MS level from which the chromatogram
 #'     was extracted.
 #'
-#' @Slot .__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun,msLevel See corresponding parameter above.
+#' @slot .__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun,msLevel See corresponding parameter above.
 #'
 #' @rdname Chromatogram-class
 Chromatogram <- function(rtime = numeric(), intensity = numeric(),

--- a/R/functions-Chromatogram.R
+++ b/R/functions-Chromatogram.R
@@ -11,12 +11,12 @@ names(.SUPPORTED_AGG_FUN_CHROM) <-
 #'     method on all super classes.
 #'
 #' @param object A \code{Chromatogram} object.
-#' 
+#'
 #' @return \code{TRUE} if the \code{object} is valid and the error messages
 #'     otherwise (i.e. a \code{character}).
-#' 
+#'
 #' @author Johannes Rainer
-#' 
+#'
 #' @noRd
 .validChromatogram <- function(object) {
     msg <- character()
@@ -78,10 +78,10 @@ names(.SUPPORTED_AGG_FUN_CHROM) <-
 #'
 #' @param precursorMz \code{numeric(2)} for SRM/MRM transitions.
 #'     Represents the mz of the precursor ion. See details for more information.
-#' 
+#'
 #' @param productMz \code{numeric(2)} for SRM/MRM transitions.
 #'     Represents the mz of the product. See details for more information.
-#' 
+#'
 #' @param fromFile \code{integer(1)} the index of the file within the
 #'     \code{\linkS4class{OnDiskMSnExp}} or \code{\linkS4class{MSnExp}}
 #'     from which the chromatogram was extracted.
@@ -93,9 +93,9 @@ names(.SUPPORTED_AGG_FUN_CHROM) <-
 #'
 #' @param msLevel \code{integer} with the MS level from which the chromatogram
 #'     was extracted.
-#' 
-#' @slot .__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun,msLevel See corresponding parameter above.
-#' 
+#'
+#' @Slot .__classVersion__,rtime,intensity,mz,filterMz,precursorMz,productMz,fromFile,aggregationFun,msLevel See corresponding parameter above.
+#'
 #' @rdname Chromatogram-class
 Chromatogram <- function(rtime = numeric(), intensity = numeric(),
                          mz = c(NA_real_, NA_real_),
@@ -142,7 +142,7 @@ Chromatogram <- function(rtime = numeric(), intensity = numeric(),
 #'
 #' @description \code{aggregationFun,aggregationFun<-} get or set the
 #'     aggregation function.
-#' 
+#'
 #' @rdname Chromatogram-class
 aggregationFun <- function(object) {
     if (!is(object, "Chromatogram"))
@@ -168,4 +168,3 @@ aggregationFun <- function(object) {
     if (validObject(object))
         object
 }
-

--- a/R/methods-Chromatograms.R
+++ b/R/methods-Chromatograms.R
@@ -102,10 +102,11 @@ setMethod("[", "Chromatograms",
                   return(x@.Data[i, j, drop = TRUE][[1]])
               pd <- x@phenoData
               fd <- x@featureData
+              xclass <- class(x)
               ## Multiple elements, return type depends on drop.
               x <- x@.Data[i = i, j = j, drop = drop]
               if (!drop) {
-                  x <- as(x, "Chromatograms")
+                  x <- as(x, xclass)
                   pd <- pd[j, ]
                   ## Drop levels
                   pData(pd) <- droplevels(pData(pd))


### PR DESCRIPTION
- Fix [,Chromatograms to support classes extending Chromatograms (issue
  https://github.com/sneumann/xcms/issues/333)

I have a class `XChromatograms` extending `Chromatograms` over in `xcms`, subsetting such classes with `[` returned **always** a `Chromatograms` object. Reason was that the type of class is hardcoded in the `[` method. This pull request fixes this.