### PR TITLE
Rename 'fun' into 'method' in combineFeatures (issue #389)

### DIFF
--- a/R/functions-MSnSet.R
+++ b/R/functions-MSnSet.R
@@ -161,7 +161,7 @@ updateFeatureNames <- function(object, label, sep = ".") {
 ##' m <- nQuants(msnset, groupBy = fData(msnset)$ProteinAccession)
 ##' msnset2 <- combineFeatures(msnset,
 ##'                            groupBy = fData(msnset)$ProteinAccession,
-##'                            fun = sum)
+##'                            method = sum)
 ##' stopifnot(dim(n) == dim(msnset2))
 ##' head(exprs(msnset2))
 ##' head(exprs(msnset2) * (n/m))

--- a/R/iPQF.R
+++ b/R/iPQF.R
@@ -226,7 +226,7 @@ uni.measured.dist <- function(pos, uniques.all, mat) {
 ##' head(exprs(msnset2))
 ##' prot <- combineFeatures(msnset2,
 ##'                         groupBy = fData(msnset2)$accession,
-##'                         fun = "iPQF")
+##'                         method = "iPQF")
 ##' head(exprs(prot))
 iPQF <- function(object, groupBy,
                  low.support.filter = FALSE,

--- a/R/methods-Spectra.R
+++ b/R/methods-Spectra.R
@@ -430,6 +430,7 @@ setMethod("smooth", "Spectra", function(x, method = c("SavitzkyGolay",
 #' set.
 #'
 #' @aliases combineSpectra
+#'
 #' @rdname combineSpectra
 #'
 #' @title Combine Spectra
@@ -440,9 +441,11 @@ setMethod("smooth", "Spectra", function(x, method = c("SavitzkyGolay",
 #'     the sets of spectra to be combined. If missing, all spectra are
 #'     considered to be one set.
 #'
-#' @param fun `function` to be used to combine the spectra by `fcol`. Has to
+#' @param fun *Deprecated* use `method` instead.
+#'
+#' @param method `function` to be used to combine the spectra by `fcol`. Has to
 #'     be a function that takes a list of spectra as input and returns a single
-#'     [Spectrum-class]. See [meanMzInts()] for details..
+#'     [Spectrum-class]. See [meanMzInts()] for details.
 #'
 #' @param ... additional arguments for `fun`.
 #'
@@ -509,7 +512,13 @@ setMethod("smooth", "Spectra", function(x, method = c("SavitzkyGolay",
 #' plot(mz(res[[2]]), intensity(res[[2]]), xlim = range(mzs[5:25]), type = "h",
 #'     col = "black")
 setMethod("combineSpectra", "Spectra", function(object, fcol,
-                                                fun = meanMzInts, ...) {
+                                                method = meanMzInts, fun, ...) {
+    if (!missing(fun)) {
+        .Deprecated(
+            msg = "Parameter 'fun' is deprecated. Please use 'method' instead")
+        if (missing(method))
+            method <- fun
+    }
     if (missing(fcol)) {
         .by <- factor(rep(1, length(object)))
     } else {
@@ -518,7 +527,7 @@ setMethod("combineSpectra", "Spectra", function(object, fcol,
         .by <- factor(mcols(object)[, fcol],
                       levels = unique(mcols(object)[, fcol]))
     }
-    res <- lapply(split(object, .by), FUN = fun, ...)
+    res <- lapply(split(object, .by), FUN = method, ...)
     elm <-  mcols(object, use.names = TRUE)[
         levelIndex(.by, which = "first"), , drop = FALSE]
     names(res) <- rownames(elm)

--- a/R/quantitation-MS2-labelfree.R
+++ b/R/quantitation-MS2-labelfree.R
@@ -90,7 +90,7 @@ SI <- function(object,
 
     ## SI: protein-wise summed tic
     object <- combineFeatures(object, groupBy = groupBy,
-                              fun = "sum", verbose = verbose)
+                              method = "sum", verbose = verbose)
 
     if (method %in% c("SIgi", "SIn"))
         exprs(object) <- exprs(object)/colSums(exprs(object))
@@ -126,7 +126,7 @@ SAF <- function(object,
 
     object <- combineFeatures(object,
                               groupBy = groupBy,
-                              fun = length,
+                              method = length,
                               verbose = verbose)
 
     plength <- fData(object)[, plength]

--- a/man/combineFeatures.Rd
+++ b/man/combineFeatures.Rd
@@ -24,10 +24,10 @@
 
 \usage{
 
-combineFeatures(object, groupBy, fun = c("mean", "median",
+combineFeatures(object, groupBy, method = c("mean", "median",
 "weighted.mean", "sum", "medpolish", "robust", "iPQF", "NTR"), fcol,
 redundancy.handler = c("unique", "multiple"), cv = TRUE, cv.norm =
-"sum", verbose = isMSnbaseVerbose(), ...)
+"sum", verbose = isMSnbaseVerbose(), fun, ...)
 
 }
 
@@ -43,7 +43,10 @@ redundancy.handler = c("unique", "multiple"), cv = TRUE, cv.norm =
     named, its names must match \code{fetureNames(object)}. See
     \code{redundancy.handler} for details about the latter. }
 
-  \item{fun}{ The summerising function. Currently, mean, median,
+  \item{fun}{Deprecated; use \code{method} instead.
+  }
+
+  \item{method}{ The summerising function. Currently, mean, median,
     weighted mean, sum, median polish, robust summarisation (using
     \code{MASS::rlm}), iPQF (see \code{\link{iPQF}} for details) and NTR
     (see \code{\link[MSnbase]{NTR}} for details) are implemented, but
@@ -173,8 +176,8 @@ fvarLabels(msnset.comb)
 grpl <- list(c("A", "B"), "A", "A", "C", c("C", "B"))
 ## optional naming
 names(grpl) <- featureNames(msnset)
-exprs(combineFeatures(msnset, grpl, fun = "sum", redundancy.handler = "unique"))
-exprs(combineFeatures(msnset, grpl, fun = "sum", redundancy.handler = "multiple"))
+exprs(combineFeatures(msnset, grpl, method = "sum", redundancy.handler = "unique"))
+exprs(combineFeatures(msnset, grpl, method = "sum", redundancy.handler = "multiple"))
 
 ## missing data
 exprs(msnset)[4, 4] <-
@@ -191,7 +194,7 @@ anyNA(msnset2)
 res <- combineFeatures(msnset2,
 		       groupBy = fData(msnset2)$accession,
 		       redundancy.handler = "unique",
-		       fun = "iPQF",
+		       method = "iPQF",
 		       low.support.filter = FALSE,
 		       ratio.calc = "sum",
 		       method.combine = FALSE)
@@ -207,13 +210,13 @@ exprs(msnset["X46", ])
 ## Only the missing value in X46 and iTRAQ4.116 will be ignored
 res <- combineFeatures(msnset,
 		       fcol = "ProteinAccession",
-		       fun = "robust")
+		       method = "robust")
 tail(exprs(res))
 
 msnset2 <- filterNA(msnset) ## remove features with missing value(s)
 res2 <- combineFeatures(msnset2,
 			fcol = "ProteinAccession",
-			fun = "robust")
+			method = "robust")
 ## Here, the values for ENO are different because the whole feature
 ## X46 that contained the missing value was removed prior to fitting.
 tail(exprs(res2))

--- a/man/combineSpectra.Rd
+++ b/man/combineSpectra.Rd
@@ -6,7 +6,8 @@
 \alias{combineSpectra}
 \title{Combine Spectra}
 \usage{
-\S4method{combineSpectra}{Spectra}(object, fcol, fun = meanMzInts, ...)
+\S4method{combineSpectra}{Spectra}(object, fcol, method = meanMzInts,
+  fun, ...)
 }
 \arguments{
 \item{object}{A \linkS4class{MSnExp} or \linkS4class{Spectra}}
@@ -15,9 +16,11 @@
 the sets of spectra to be combined. If missing, all spectra are
 considered to be one set.}
 
-\item{fun}{\code{function} to be used to combine the spectra by \code{fcol}. Has to
+\item{method}{\code{function} to be used to combine the spectra by \code{fcol}. Has to
 be a function that takes a list of spectra as input and returns a single
-\linkS4class{Spectrum}. See \code{\link[=meanMzInts]{meanMzInts()}} for details..}
+\linkS4class{Spectrum}. See \code{\link[=meanMzInts]{meanMzInts()}} for details.}
+
+\item{fun}{\emph{Deprecated} use \code{method} instead.}
 
 \item{...}{additional arguments for \code{fun}.}
 }

--- a/man/iPQF.Rd
+++ b/man/iPQF.Rd
@@ -53,7 +53,7 @@ data(msnset2)
 head(exprs(msnset2))
 prot <- combineFeatures(msnset2,
                         groupBy = fData(msnset2)$accession,
-                        fun = "iPQF")
+                        method = "iPQF")
 head(exprs(prot))
 }
 \references{

--- a/man/nQuants.Rd
+++ b/man/nQuants.Rd
@@ -47,7 +47,7 @@ msnset <- topN(msnset, groupBy = fData(msnset)$ProteinAccession, n)
 m <- nQuants(msnset, groupBy = fData(msnset)$ProteinAccession)
 msnset2 <- combineFeatures(msnset,
                            groupBy = fData(msnset)$ProteinAccession,
-                           fun = sum)
+                           method = sum)
 stopifnot(dim(n) == dim(msnset2))
 head(exprs(msnset2))
 head(exprs(msnset2) * (n/m))

--- a/tests/testthat/test_MSnSet.R
+++ b/tests/testthat/test_MSnSet.R
@@ -108,8 +108,8 @@ test_that("Combine MSnSet features (V)", {
     gb2 <- factor(c("a", "c", "z", "a", "z", "b", "b", "a", "c", "a"))
     gb3 <- factor(rev(c("a", "c", "z", "a", "z", "b", "b", "a", "c", "a")))
     fData(aa)$Z <- gb2
-    zz <- combineFeatures(aa, gb2, fun = "sum")
-    zz3 <- combineFeatures(aa[10:1, ], gb3, fun = "sum")
+    zz <- combineFeatures(aa, gb2, method = "sum")
+    zz3 <- combineFeatures(aa[10:1, ], gb3, method = "sum")
     expect_equal(exprs(zz), exprs(zz3))
     expect_equal(fData(zz)[, 3:5], fData(zz3)[, 3:5], tolerance=1e-5)
     expect_true(all.equal(as.numeric(exprs(zz["a", ])),
@@ -432,12 +432,12 @@ test_that("Robust summary and sample names order (bug PR# 349)", {
     ## Expected results
     res0 <- combineFeatures(msnset,
                             fcol = "ProteinAccession",
-                            fun = "robust")
+                            method = "robust")
     ## Identify the bug
     sampleNames(msnset2)[1] <- "zzz"
     res2 <- combineFeatures(msnset2,
                             fcol = "ProteinAccession",
-                            fun = "robust")
+                            method = "robust")
     ## Re-set sample name
     sampleNames(res2) <- sampleNames(res0)
     expect_equal(exprs(res0), exprs(res2))

--- a/tests/testthat/test_NTR.R
+++ b/tests/testthat/test_NTR.R
@@ -44,12 +44,12 @@ test_that("normToReference", {
                c(1/2, 1/2, 1, NA))
 })
 
-test_that("combineFeatures(..., fun=\"NTR\")", {
+test_that("combineFeatures(..., method=\"NTR\")", {
   data(msnset)
   pa <- fData(msnset)$ProteinAccession
 
-  ntr <- combineFeatures(msnset, groupBy=pa, fun="NTR")
-  ntrref <- combineFeatures(msnset, groupBy=pa, fun="NTR", reference=
+  ntr <- combineFeatures(msnset, groupBy=pa, method="NTR")
+  ntrref <- combineFeatures(msnset, groupBy=pa, method="NTR", reference=
     exprs(msnset)[cbind(1:55, c(4, 4, 2, 3, 2, 3, 2, 4, 2, 2, 3, 4, 4, 4, 2,
                                 1, 4, 3, 4, 1, 3, 3, 3, 2, 2, 3, 3, 2, 3, 3,
                                 3, 4, 1, 4, 4, 3, 4, 3, 1, 4, 1, 1, 3, 3, 4,
@@ -59,8 +59,8 @@ test_that("combineFeatures(..., fun=\"NTR\")", {
   ## sum and NTR are equal if the reference is
   ## 1/(number of peptides per protein) and contains no NA
   ref <- (1/table(pa)[pa])
-  ntr <- combineFeatures(msnset, groupBy=pa, fun="NTR", reference=ref)
-  s <- combineFeatures(msnset, groupBy=pa, fun="sum")
+  ntr <- combineFeatures(msnset, groupBy=pa, method="NTR", reference=ref)
+  s <- combineFeatures(msnset, groupBy=pa, method="sum")
   ## exclude ENO (because of one NA the ref is not correct)
   ntr <- ntr[featureNames(ntr) != "ENO"]
   s <- s[featureNames(s) != "ENO"]

--- a/tests/testthat/test_iPQF.R
+++ b/tests/testthat/test_iPQF.R
@@ -21,7 +21,7 @@ test_that("iPQF unit test", {
               res1 <- combineFeatures(msnset2,
                                       groupBy = fData(msnset2)$accession,
                                       redundancy.handler = "unique",
-                                      fun = "iPQF",
+                                      method = "iPQF",
                                       low.support.filter = FALSE,
                                       ratio.calc = "sum",
                                       method.combine = FALSE)
@@ -33,17 +33,17 @@ test_that("iPQF unit test", {
               dflt <- combineFeatures(msnset2,
                                       groupBy = fData(msnset2)$accession,
                                       redundancy.handler = "unique",
-                                      fun = "iPQF")
+                                      method = "iPQF")
               dflt@processingData <- processingData(ipqf1)
               dflt@experimentData <- experimentData(ipqf1)
               res1@.__classVersion__ <- dflt@.__classVersion__
               expect_true(all.equal(res1, dflt))
-              
+
 
               res2 <- combineFeatures(msnset2,
                                       groupBy = fData(msnset2)$accession,
                                       redundancy.handler = "unique",
-                                      fun = "iPQF",
+                                      method = "iPQF",
                                       low.support.filter = FALSE,
                                       ratio.calc = "sum",
                                       method.combine = TRUE)
@@ -55,7 +55,7 @@ test_that("iPQF unit test", {
               res3 <- combineFeatures(msnset2,
                                       groupBy = fData(msnset2)$accession,
                                       redundancy.handler = "unique",
-                                      fun = "iPQF",
+                                      method = "iPQF",
                                       low.support.filter = TRUE,
                                       ratio.calc = "sum",
                                       method.combine = FALSE)
@@ -67,7 +67,7 @@ test_that("iPQF unit test", {
               res4 <- combineFeatures(msnset2,
                                       groupBy = fData(msnset2)$accession,
                                       redundancy.handler = "unique",
-                                      fun = "iPQF",
+                                      method = "iPQF",
                                       low.support.filter = TRUE,
                                       ratio.calc = "none",
                                       method.combine = FALSE)
@@ -79,7 +79,7 @@ test_that("iPQF unit test", {
               res5 <- combineFeatures(msnset2,
                                       groupBy = fData(msnset2)$accession,
                                       redundancy.handler = "unique",
-                                      fun = "iPQF",
+                                      method = "iPQF",
                                       low.support.filter = TRUE,
                                       ratio.calc = "X114.ions",
                                       method.combine = FALSE)

--- a/tests/testthat/test_robust.R
+++ b/tests/testthat/test_robust.R
@@ -207,14 +207,14 @@ test_that("Robust summarisation", {
     ## Single NA value is removed prior to fit
     expect_message(res1 <- combineFeatures(msnset,
                                            fcol = "ProteinAccession",
-                                           fun = "robust",
+                                           method = "robust",
                                            maxit = 100L))
     expect_equal(exp1, exprs(res1))
     ## remove feature with missing value
     msnset <- filterNA(msnset)
     res2 <- combineFeatures(msnset,
                             fcol = "ProteinAccession",
-                            fun = "robust",
+                            method = "robust",
                             maxit = 100L)
 
     expect_equal(exp2, exprs(res2))

--- a/vignettes/v01-MSnbase-demo.Rmd
+++ b/vignettes/v01-MSnbase-demo.Rmd
@@ -1342,17 +1342,17 @@ table(gb)
 length(unique(gb))
 ```
 
-The third argument, `fun`, defined how to combine the
+The third argument, `method`, defined how to combine the
 features. Predefined functions are readily available and can be
-specified as strings (`fun="mean"`, `fun="median"`, `fun="sum"`,
-`fun="weighted.mean"` or `fun="medianpolish"` to compute respectively
+specified as strings (`method="mean"`, `method="median"`, `method="sum"`,
+`method="weighted.mean"` or `method="medianpolish"` to compute respectively
 the mean, media, sum, weighted mean or median polish of the features
 to be aggregated).  Alternatively, is is possible to supply user
-defined functions with `fun=function(x) { ... }`. We will use the
+defined functions with `method=function(x) { ... }`. We will use the
 `median` here.
 
 ```{r combineFeatures, echo=TRUE, cache=FALSE}
-qnt2 <- combineFeatures(qnt, groupBy = gb, fun = "median")
+qnt2 <- combineFeatures(qnt, groupBy = gb, method = "median")
 qnt2
 ```
 
@@ -1379,7 +1379,7 @@ sc <- quantify(msexp, method = "count")
 fData(sc)$DatabaseAccess[1] <- fData(sc)$DatabaseAccess[2]
 fData(sc)$DatabaseAccess
 sc <- combineFeatures(sc, groupBy = fData(sc)$DatabaseAccess,
-                      fun = "sum")
+                      method = "sum")
 exprs(sc)
 ```
 


### PR DESCRIPTION
- Rename parameter 'fun' into 'method' in combineFeatures and combineSpectra
  methods.
- Display deprecation warning if 'fun' is used.
- Update documentation, examples and vignette to use 'method' instead of 'fun'.