### PR TITLE
Bring hdf5 branch up-to-date

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,12 +7,14 @@ import(ProtGenerics)
 import(BiocParallel)
 import(Biobase)
 import(mzR)
-import(rhdf5)
 import(impute)
 
 import(scales)
 import(lattice)
 import(methods)
+
+importFrom(rhdf5, H5Fcreate, H5Fclose, H5Fopen, h5createGroup, h5write,
+           h5delete, H5Lexists)
 
 importFrom(progress, progress_bar)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,7 +14,7 @@ import(lattice)
 import(methods)
 
 importFrom(rhdf5, H5Fcreate, H5Fclose, H5Fopen, h5createGroup, h5write,
-           h5delete, H5Lexists)
+           h5delete, H5Lexists, h5read)
 
 importFrom(progress, progress_bar)
 
@@ -57,7 +57,7 @@ importClassesFrom(IRanges, IRanges)
 importFrom(affy, MAplot, ma.plot, mva.pairs)
 importFrom(mzID, mzID, flatten)
 importClassesFrom(mzID, mzID, mzIDCollection)
-importFrom(digest, digest)
+importFrom(digest, digest, sha1)
 importFrom(grDevices, topo.colors)
 
 export(MSnSet,
@@ -162,7 +162,7 @@ export(MSnSet,
        readHdf5DiskMSData,
        hdf5FileName,
        setHdf5CompressionLevel,
-       consolidate
+       writeHdf5Data
        )
 
 exportClasses(pSet,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -162,7 +162,7 @@ export(MSnSet,
        readHdf5DiskMSData,
        hdf5FileName,
        setHdf5CompressionLevel,
-       writeHdf5Data,
+       updateHdf5Data,
        convertToHdf5MSnExp
        )
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -162,7 +162,8 @@ export(MSnSet,
        readHdf5DiskMSData,
        hdf5FileName,
        setHdf5CompressionLevel,
-       writeHdf5Data
+       writeHdf5Data,
+       convertToHdf5MSnExp
        )
 
 exportClasses(pSet,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -161,7 +161,8 @@ export(MSnSet,
        ## hdf5 backend
        readHdf5DiskMSData,
        hdf5FileName,
-       setHdf5CompressionLevel
+       setHdf5CompressionLevel,
+       consolidate
        )
 
 exportClasses(pSet,

--- a/R/hdf5.R
+++ b/R/hdf5.R
@@ -96,11 +96,11 @@ validHdf5MSnExp <- function(object, check_md5 = TRUE) {
 #' MSnbase:::validHdf5MSnExp(x)
 #' x[[12]]
 #'
-#' ## writeHdf5Data will make all data manipulations persistent, it will
+#' ## updateHdf5Data will make all data manipulations persistent, it will
 #' ## overwrite the data in the hdf5 files associated with x_clean and
 #' ## accessing the data afterwards will no longer require to apply
 #' ## data manipulations on-the-fly.
-#' writeHdf5Data(x_clean)
+#' updateHdf5Data(x_clean)
 #'
 #' x_clean[[12]]
 #'
@@ -473,7 +473,7 @@ setMethod("filterFile", "Hdf5MSnExp", function(object, file) {
 
 #' @description
 #'
-#' `writeHdf5Data` *consolidates* an `Hdf5MSnExp` object by applying all
+#' `updateHdf5Data` *consolidates* an `Hdf5MSnExp` object by applying all
 #' registered processing steps to each spectrum and saving the updated
 #' data to the hdf5 file(s) associated with the sample(s) in `x`. This has
 #' some implications on copies of the input object. See notes for more
@@ -481,7 +481,7 @@ setMethod("filterFile", "Hdf5MSnExp", function(object, file) {
 #'
 #' @note
 #'
-#' `writeHdf5Data` will overwrite the content of the hdf5 file(s) associated
+#' `updateHdf5Data` will overwrite the content of the hdf5 file(s) associated
 #' with the `Hdf5MSnExp`. Thus, if another copy of the object, prior to any data
 #' manipulations, exists that points to the same hdf5 files, that object might
 #' become corrupt. Note that `convertToHdf5MSnExp` can *restore* corrupted
@@ -492,7 +492,7 @@ setMethod("filterFile", "Hdf5MSnExp", function(object, file) {
 #' @md
 #'
 #' @rdname Hdf5MSnExp-class
-writeHdf5Data <- function(x) {
+updateHdf5Data <- function(x) {
     if (isMSnbaseVerbose())
         message("Note: after writing data to hdf5 files any copy of the input",
                 " object linking to the same hdf5 files will no longer be ",

--- a/R/hdf5.R
+++ b/R/hdf5.R
@@ -349,6 +349,20 @@ setMethod("spectrapply", "Hdf5MSnExp", function(object, FUN = NULL,
     vals[rownames(fData(object))]
 })
 
+setMethod("filterFile", "Hdf5MSnExp", function(object, file) {
+    fnames <- fileNames(object)
+    object <- callNextMethod()
+    object@hdf5file <- object@hdf5file[match(fileNames(object), fnames)]
+    if (validObject(object))
+        object
+})
+
+consolidate <- function(x, ...) {
+    stopifnot(inherits(x, "Hdf5MSnExp"))
+    x_split <- splitByFile(x, f = factor(fileNames(x)))
+
+}
+
 ## consolidate:
 ## - For an Hdf5MSnExp, do per file:
 ## - read spectra.

--- a/man/Hdf5MSnExp-class.Rd
+++ b/man/Hdf5MSnExp-class.Rd
@@ -9,7 +9,7 @@
 \alias{readHdf5DiskMSData}
 \alias{hdf5FileName}
 \alias{spectrapply,Hdf5MSnExp-method}
-\alias{writeHdf5Data}
+\alias{updateHdf5Data}
 \title{The \code{Hdf5MSnExp} Class for MS Data And Meta-Data}
 \usage{
 convertToHdf5MSnExp(object, verbose = FALSE, hdf5path = ".",
@@ -24,7 +24,7 @@ hdf5FileName(object)
 \S4method{spectrapply}{Hdf5MSnExp}(object, FUN = NULL,
   BPPARAM = bpparam(), ...)
 
-writeHdf5Data(x)
+updateHdf5Data(x)
 }
 \arguments{
 \item{x}{\code{Hdf5MSnExp} object.}
@@ -46,7 +46,7 @@ included in the main \code{readMSData} function.
 \code{convertToHdf5MSnExp} coerces an \link{OnDiskMSnExp} object (or any object
 extending it) to an \code{Hdf5MSnExp} object.
 
-\code{writeHdf5Data} \emph{consolidates} an \code{Hdf5MSnExp} object by applying all
+\code{updateHdf5Data} \emph{consolidates} an \code{Hdf5MSnExp} object by applying all
 registered processing steps to each spectrum and saving the updated
 data to the hdf5 file(s) associated with the sample(s) in \code{x}. This has
 some implications on copies of the input object. See notes for more
@@ -60,7 +60,7 @@ per input mzML file/sample.}
 }}
 
 \note{
-\code{writeHdf5Data} will overwrite the content of the hdf5 file(s) associated
+\code{updateHdf5Data} will overwrite the content of the hdf5 file(s) associated
 with the \code{Hdf5MSnExp}. Thus, if another copy of the object, prior to any data
 manipulations, exists that points to the same hdf5 files, that object might
 become corrupt. Note that \code{convertToHdf5MSnExp} can \emph{restore} corrupted
@@ -92,11 +92,11 @@ x_clean[[12]]
 MSnbase:::validHdf5MSnExp(x)
 x[[12]]
 
-## writeHdf5Data will make all data manipulations persistent, it will
+## updateHdf5Data will make all data manipulations persistent, it will
 ## overwrite the data in the hdf5 files associated with x_clean and
 ## accessing the data afterwards will no longer require to apply
 ## data manipulations on-the-fly.
-writeHdf5Data(x_clean)
+updateHdf5Data(x_clean)
 
 x_clean[[12]]
 

--- a/man/Hdf5MSnExp-class.Rd
+++ b/man/Hdf5MSnExp-class.Rd
@@ -20,24 +20,24 @@ hdf5FileName(object)
   BPPARAM = bpparam(), ...)
 }
 \description{
-The \code{Hdf5MSnExp} class encapsulates data and
-meta-data for mass spectrometry experiments like the \code{MSnExp}
-and \code{OnDiskMSnExp} classes. \code{Hdf5MSnExp} implements, like
-\code{OnDiskMSnExp}, an \emph{on disk} model, where the raw data (M/Z
-and intensities) are stored on disk (rather than in memory,
-like \code{MSnExp} data) using, as the name implies, the hdf5 file
-format. See \code{\link{MSnExp}} and \code{\link{OnDiskMSnExp}} for a more general
-description of the data, slots and operations.\preformatted{Object of the class are currently created with the
-`readHdf5DiskMSData` function. Later, this backend will be
-included in the main `readMSData` function.
-}
+The \code{Hdf5MSnExp} class encapsulates data and meta-data for mass
+spectrometry experiments like the \code{MSnExp} and \code{OnDiskMSnExp}
+classes. \code{Hdf5MSnExp} implements, like \code{OnDiskMSnExp}, an
+\emph{on disk} model, where the raw data (M/Z and intensities) are
+stored on disk (rather than in memory, like \code{MSnExp} data) using,
+as the name implies, the hdf5 file format. See \code{\link{MSnExp}} and
+\code{\link{OnDiskMSnExp}} for a more general description of the data,
+slots and operations.
+
+Object of the class are currently created with the
+\code{readHdf5DiskMSData} function. Later, this backend will be
+included in the main \code{readMSData} function.
 }
 \section{Slots}{
 
 \describe{
-\item{\code{hdf5file}}{\code{character(1)} containing the hdf5 filename.}
-
-\item{\code{hdf5handle}}{A \code{H5IdComponent} or \code{NULL}.}
+\item{\code{hdf5file}}{\code{character} containing the hdf5 filenames, one file
+per input mzML file/sample.}
 }}
 
 \examples{
@@ -62,5 +62,5 @@ rm(x)
 See \code{\link{MSnExp}} and \code{\link{OnDiskMSnExp}} classes.
 }
 \author{
-Laurent Gatto
+Laurent Gatto, Johannes Rainer
 }

--- a/man/Hdf5MSnExp-class.Rd
+++ b/man/Hdf5MSnExp-class.Rd
@@ -5,12 +5,16 @@
 \alias{Hdf5MSnExp-class}
 \alias{.Hdf5MSnExp}
 \alias{Hdf5MSnExp}
+\alias{convertToHdf5MSnExp}
 \alias{readHdf5DiskMSData}
 \alias{hdf5FileName}
 \alias{spectrapply,Hdf5MSnExp-method}
 \alias{writeHdf5Data}
 \title{The \code{Hdf5MSnExp} Class for MS Data And Meta-Data}
 \usage{
+convertToHdf5MSnExp(object, verbose = FALSE, hdf5path = ".",
+  BPPARAM = bpparam())
+
 readHdf5DiskMSData(files, pdata = NULL, msLevel. = NULL,
   verbose = isMSnbaseVerbose(), centroided. = NA, smoothed. = NA,
   hdf5path = ".", BPPARAM = bpparam())
@@ -39,6 +43,9 @@ Object of the class are currently created with the
 \code{readHdf5DiskMSData} function. Later, this backend will be
 included in the main \code{readMSData} function.
 
+\code{convertToHdf5MSnExp} coerces an \link{OnDiskMSnExp} object (or any object
+extending it) to an \code{Hdf5MSnExp} object.
+
 \code{writeHdf5Data} \emph{consolidates} an \code{Hdf5MSnExp} object by applying all
 registered processing steps to each spectrum and saving the updated
 data to the hdf5 file(s) associated with the sample(s) in \code{x}. This has
@@ -53,10 +60,11 @@ per input mzML file/sample.}
 }}
 
 \note{
-\code{consolidate} will overwrite the content of the hdf5 file(s) associated with
-the \code{Hdf5MSnExp}. Thus, if another copy of the object, prior to any data
+\code{writeHdf5Data} will overwrite the content of the hdf5 file(s) associated
+with the \code{Hdf5MSnExp}. Thus, if another copy of the object, prior to any data
 manipulations, exists that points to the same hdf5 files, that object might
-become corrupt.
+become corrupt. Note that \code{convertToHdf5MSnExp} can \emph{restore} corrupted
+\code{Hdf5MSnExp} files again (see examples for details).
 }
 \examples{
 f <- msdata::proteomics(pattern = "MS3TMT11", full.names = TRUE)
@@ -98,6 +106,13 @@ x_clean[[12]]
 MSnbase:::validHdf5MSnExp(x)
 
 ## Accessing the data such as with x[[12]] will thus result in an error.
+## The data can however be *restored* with the `convertToHdf5MSnExp`
+## function that will re-read all data into hdf5 files. Note that a
+## different `hdf5path` has to be used.
+x <- convertToHdf5MSnExp(x, hdf5path = paste0(tempdir(), "/2/"))
+
+MSnbase:::validHdf5MSnExp(x)
+x[[12]]
 
 ## clean up session
 file.remove(hdf5FileName(x))

--- a/man/Hdf5MSnExp-class.Rd
+++ b/man/Hdf5MSnExp-class.Rd
@@ -55,7 +55,7 @@ filterMsLevel(x, 3L)[[1]]
 
 ## clean up session
 file.remove(hdf5FileName(x))
-validHdf5MSnExp(x) ## not valid anymore
+MSnbase:::validHdf5MSnExp(x) ## not valid anymore
 rm(x)
 }
 \seealso{

--- a/man/Hdf5MSnExp-class.Rd
+++ b/man/Hdf5MSnExp-class.Rd
@@ -8,6 +8,7 @@
 \alias{readHdf5DiskMSData}
 \alias{hdf5FileName}
 \alias{spectrapply,Hdf5MSnExp-method}
+\alias{writeHdf5Data}
 \title{The \code{Hdf5MSnExp} Class for MS Data And Meta-Data}
 \usage{
 readHdf5DiskMSData(files, pdata = NULL, msLevel. = NULL,
@@ -18,6 +19,11 @@ hdf5FileName(object)
 
 \S4method{spectrapply}{Hdf5MSnExp}(object, FUN = NULL,
   BPPARAM = bpparam(), ...)
+
+writeHdf5Data(x)
+}
+\arguments{
+\item{x}{\code{Hdf5MSnExp} object.}
 }
 \description{
 The \code{Hdf5MSnExp} class encapsulates data and meta-data for mass
@@ -32,6 +38,12 @@ slots and operations.
 Object of the class are currently created with the
 \code{readHdf5DiskMSData} function. Later, this backend will be
 included in the main \code{readMSData} function.
+
+\code{writeHdf5Data} \emph{consolidates} an \code{Hdf5MSnExp} object by applying all
+registered processing steps to each spectrum and saving the updated
+data to the hdf5 file(s) associated with the sample(s) in \code{x}. This has
+some implications on copies of the input object. See notes for more
+information.
 }
 \section{Slots}{
 
@@ -40,9 +52,15 @@ included in the main \code{readMSData} function.
 per input mzML file/sample.}
 }}
 
+\note{
+\code{consolidate} will overwrite the content of the hdf5 file(s) associated with
+the \code{Hdf5MSnExp}. Thus, if another copy of the object, prior to any data
+manipulations, exists that points to the same hdf5 files, that object might
+become corrupt.
+}
 \examples{
 f <- msdata::proteomics(pattern = "MS3TMT11", full.names = TRUE)
-x <- readHdf5DiskMSData(f)
+x <- readHdf5DiskMSData(f, hdf5path = tempdir())
 x
 
 ## automatically generated hdf5 file
@@ -53,10 +71,36 @@ x[[2]]
 x[[10]]
 filterMsLevel(x, 3L)[[1]]
 
+## Perform data manipulations, remove all peaks with an intensity
+## smaller than 1000
+x_clean <- clean(removePeaks(x, t = 1000), all = TRUE)
+
+x_clean[[12]]
+
+## Data manipulations are, as for OnDiskMSnExp objects, performed
+## on-the-fly. The data in the hdf5 files was not changed by the
+## clean and removePeaks calls above. Object x is thus still valid
+## and we can still use it.
+MSnbase:::validHdf5MSnExp(x)
+x[[12]]
+
+## writeHdf5Data will make all data manipulations persistent, it will
+## overwrite the data in the hdf5 files associated with x_clean and
+## accessing the data afterwards will no longer require to apply
+## data manipulations on-the-fly.
+writeHdf5Data(x_clean)
+
+x_clean[[12]]
+
+## Note that the original object x is however still associated with the
+## same hdf5 files. This object will now no longer be valid, as the data
+## has changed for it.
+MSnbase:::validHdf5MSnExp(x)
+
+## Accessing the data such as with x[[12]] will thus result in an error.
+
 ## clean up session
 file.remove(hdf5FileName(x))
-MSnbase:::validHdf5MSnExp(x) ## not valid anymore
-rm(x)
 }
 \seealso{
 See \code{\link{MSnExp}} and \code{\link{OnDiskMSnExp}} classes.

--- a/tests/testthat/test_hdf5.R
+++ b/tests/testthat/test_hdf5.R
@@ -131,3 +131,24 @@ test_that(".h5write_spectra works", {
     cont <- rhdf5::h5ls(h5f)
     expect_equal(nrow(cont), length(idx) + 1)
 })
+
+test_that("filterFile,Hdf5MSnExp works", {
+    res <- filterFile(h5_sciex)
+    expect_equal(fileNames(res), fileNames(h5_sciex))
+    expect_equal(res@hdf5file, h5_sciex@hdf5file)
+    expect_equal(fData(res), fData(h5_sciex))
+
+    res <- filterFile(h5_sciex, 1)
+    expect_equal(fileNames(res), fileNames(h5_sciex)[1])
+    expect_equal(res@hdf5file, h5_sciex@hdf5file[1])
+    fd <- fData(h5_sciex)
+    expect_equal(fData(res), fd[fd$fileIdx == 1, ])
+
+    res <- filterFile(h5_sciex, 2)
+    expect_equal(fileNames(res), fileNames(h5_sciex)[2])
+    expect_equal(res@hdf5file, h5_sciex@hdf5file[2])
+    fd <- fData(h5_sciex)
+    fd <- fd[fd$fileIdx == 2, ]
+    fd$fileIdx <- 1
+    expect_equal(fData(res), fd)
+})

--- a/tests/testthat/test_hdf5.R
+++ b/tests/testthat/test_hdf5.R
@@ -167,7 +167,7 @@ test_that("filterFile,Hdf5MSnExp works", {
     expect_equal(fData(res), fd)
 })
 
-test_that("writeHdf5Data works", {
+test_that("updateHdf5Data works", {
     ## Filter by retention time.
     sciex_flt <- filterRt(h5_sciex, rt = c(10, 100))
     sps <- spectra(sciex_flt)
@@ -190,7 +190,7 @@ test_that("writeHdf5Data works", {
     })
     ## Consolidate with in-place replacement.
     md5_before <- res_cent@md5sum
-    writeHdf5Data(res_cent)
+    updateHdf5Data(res_cent)
     md5_after <- res_cent@md5sum
     expect_true(all(md5_before != md5_after))
 

--- a/tests/testthat/test_hdf5.R
+++ b/tests/testthat/test_hdf5.R
@@ -27,7 +27,16 @@ test_that(".serialize_msfile_to_hdf5 works", {
     expect_equal(nrow(cont), sum(fromFile(sciex) == 1) + 2)
 })
 
-test_that("serialize_to_hdf5 works", {
+test_that("serialise_to_hdf5 and convertToHdf5MSnExp work", {
+    obj <- filterFile(sciex, 1)
+    res <- MSnbase:::serialise_to_hdf5(as(obj, "Hdf5MSnExp"),
+                                       path = paste0(tempdir(), "/tmp/"))
+    expect_true(is(res, "Hdf5MSnExp"))
+    expect_true(validObject(res))
+    expect_error(convertToHdf5MSnExp(obj, hdf5path = paste0(tempdir(), "/tmp/")))
+    res2 <- convertToHdf5MSnExp(obj, hdf5path = paste0(tempdir(), "/tmp2/"))
+    expect_true(is(res2, "Hdf5MSnExp"))
+    expect_true(validObject(res2))
 })
 
 test_that("readHdf5DiskMSnData works", {

--- a/tests/testthat/test_hdf5.R
+++ b/tests/testthat/test_hdf5.R
@@ -7,25 +7,24 @@ h5_tmt <- readHdf5DiskMSData(f, hdf5path = tempdir())
 
 test_that("validHdf5MSnExp works", {
     expect_true(MSnbase:::validHdf5MSnExp(h5_sciex))
+    expect_true(validObject(h5_sciex))
     tmp <- h5_sciex
     tmp@hdf5file <- tmp@hdf5file[2]
-    res <- MSnbase:::validHdf5MSnExp(tmp)
+    res <- MSnbase:::validHdf5MSnExp(tmp, check_md5 = FALSE)
     expect_true(is.character(res))
     tmp@hdf5file <- c(tmp@hdf5file, "a")
-    res <- MSnbase:::validHdf5MSnExp(tmp)
+    res <- MSnbase:::validHdf5MSnExp(tmp, check_md5 = FALSE)
     expect_true(is.character(res))
-})
+    expect_error(validObject(tmp))
 
-test_that(".onDisk2hdf5 works", {
-    res <- MSnbase:::.onDisk2hdf5(sciex, filename = h5_sciex@hdf5file)
-    expect_true(is(res, "Hdf5MSnExp"))
-    expect_true(MSnbase:::validHdf5MSnExp(res))
+    expect_true(MSnbase:::.h5_check_md5(h5_sciex))
 })
 
 test_that(".serialize_msfile_to_hdf5 works", {
-    h5 <- MSnbase:::.serialize_msfile_to_hdf5(fileNames(sciex)[1], tempfile())
+    h5 <- tempfile()
+    md5 <- MSnbase:::.serialize_msfile_to_hdf5(fileNames(sciex)[1], h5)
     cont <- rhdf5::h5ls(h5)
-    expect_equal(nrow(cont), sum(fromFile(sciex) == 1) + 1)
+    expect_equal(nrow(cont), sum(fromFile(sciex) == 1) + 2)
 })
 
 test_that("serialize_to_hdf5 works", {
@@ -37,11 +36,11 @@ test_that("readHdf5DiskMSnData works", {
 test_that("hdf5FileName works", {
 })
 
-test_that(".hdf5_group_name works", {
-    res <- MSnbase:::.hdf5_group_name(c("a/bb b/ccc", "a/bbb/ccc"))
+test_that(".h5_group_name works", {
+    res <- MSnbase:::.h5_group_name(c("a/bb b/ccc", "a/bbb/ccc"))
     expect_equal(length(res), 2)
     expect_true(length(unique(res)) == 2)
-    res <- MSnbase:::.hdf5_group_name(
+    res <- MSnbase:::.h5_group_name(
         c("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bb b/ccc",
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbb/ccc"))
     expect_equal(length(res), 2)
@@ -49,12 +48,12 @@ test_that(".hdf5_group_name works", {
 })
 
 
-test_that(".h5read_bare works", {
-    grps <- MSnbase:::.hdf5_group_name(fileNames(h5_sciex))
-    expect_error(.h5read_bare())
-    expect_error(.h5read_bare("5"))
+test_that(".h5_read_bare works", {
+    grps <- MSnbase:::.h5_group_name(fileNames(h5_sciex))
+    expect_error(.h5_read_bare())
+    expect_error(.h5_read_bare("5"))
     fid <- .Call("_H5Fopen", h5_sciex@hdf5file, 0L, PACKAGE = "rhdf5")
-    res <- MSnbase:::.h5read_bare(fid, paste0(grps[1], "/3"))
+    res <- MSnbase:::.h5_read_bare(fid, paste0(grps[1], "/3"))
     .Call("_H5Fclose", fid, PACKAGE = "rhdf5")
     res_2 <- rhdf5::h5read(h5_sciex@hdf5file[1],
                            name = paste0(grps[1], "/3"))
@@ -64,23 +63,28 @@ test_that(".h5read_bare works", {
 })
 
 test_that(".read_spectra_hdf5 works", {
-    res_h5 <- MSnbase:::.hdf5_read_spectra(fData(h5_sciex)[fromFile(h5_sciex) == 1, ],
-                                           h5_sciex@hdf5file[1],
-                                           fileNames(h5_sciex)[1])
+    fd <- fData(h5_sciex)
+    res_h5 <- MSnbase:::.h5_read_spectra(fd[fd$fileIdx == 1, , drop = FALSE],
+                                         h5_sciex@hdf5file[1],
+                                         h5_sciex@md5sum[1],
+                                         fileNames(h5_sciex)[1])
     res_od <- spectra(sciex)[fromFile(sciex) == 1]
     expect_equal(res_h5, res_od)
     idx <- c(34, 65, 234, 453, 488)
-    res_h5 <- MSnbase:::.hdf5_read_spectra(fData(h5_sciex)[idx, ], h5_sciex@hdf5file[1],
-                                 fileNames(h5_sciex)[1])
+    res_h5 <- MSnbase:::.h5_read_spectra(fd[idx, ], h5_sciex@hdf5file[1],
+                                         h5_sciex@md5sum[1],
+                                         fileNames(h5_sciex)[1])
     expect_equal(res_h5, res_od[idx])
     ## MS1 & 2 data
-    res_h5 <- MSnbase:::.hdf5_read_spectra(fData(h5_tmt), h5_tmt@hdf5file,
-                                 fileNames(h5_tmt))
+    res_h5 <- MSnbase:::.h5_read_spectra(fData(h5_tmt), h5_tmt@hdf5file,
+                                         h5_tmt@md5sum,
+                                         fileNames(h5_tmt))
     res_od <- spectra(tmt_erwinia_on_disk)
     expect_equal(res_h5, res_od)
-    expect_equal(res_od[123], MSnbase:::.hdf5_read_spectra(fData(h5_tmt)[123, ],
-                                                 h5_tmt@hdf5file,
-                                                 fileNames(h5_tmt)))
+    expect_equal(res_od[123], MSnbase:::.h5_read_spectra(fData(h5_tmt)[123, ],
+                                                         h5_tmt@hdf5file,
+                                                         h5_tmt@md5sum,
+                                                         fileNames(h5_tmt)))
 })
 
 test_that("spectrapply,Hdf5MSnExp works", {
@@ -98,7 +102,7 @@ test_that("spectrapply,Hdf5MSnExp works", {
     expect_warning(expect_equal(spectra(tmp_tmt), spectra(tmp_h5)))
 })
 
-test_that(".h5write_spectra works", {
+test_that(".h5_write_spectra works", {
     one_f <- filterFile(sciex, 1)
     sps <- spectra(one_f)
     fd <- fData(one_f)
@@ -107,29 +111,30 @@ test_that(".h5write_spectra works", {
     h5 <- H5Fcreate(h5f)
     H5Fclose(h5)
     fln <- "test"
-    grp <- MSnbase:::.hdf5_group_name(fln)
-    .h5write_spectra(sps, h5f, group = grp, prune = FALSE)
+    grp <- MSnbase:::.h5_group_name(fln)
+    md5 <- MSnbase:::.h5_write_spectra(sps, h5f, group = grp, prune = FALSE)
 
-    res <- MSnbase:::.hdf5_read_spectra(fd, h5f, fln)
+    expect_error(MSnbase:::.h5_read_spectra(fd, h5f, "123", fln))
+    res <- MSnbase:::.h5_read_spectra(fd, h5f, md5, fln)
     expect_equal(unname(res), unname(sps))
 
     ## Update writing only a subset.
     idx <- c(1, 45, 65, 123, 434, 894)
-    .h5write_spectra(sps[idx], h5f, group = grp, prune = TRUE)
-    res <- MSnbase:::.hdf5_read_spectra(fd[idx, ], h5f, fln)
+    md5 <- MSnbase:::.h5_write_spectra(sps[idx], h5f, group = grp, prune = TRUE)
+    res <- MSnbase:::.h5_read_spectra(fd[idx, ], h5f, md5, fln)
     expect_equal(unname(res), unname(sps[idx]))
     cont <- rhdf5::h5ls(h5f)
-    expect_equal(nrow(cont), length(idx) + 1)
+    expect_equal(nrow(cont), length(idx) + 2)
 
     ## Writing empty spectra?
     sps[[1]] <- clean(removePeaks(sps[[1]], t = 10e9), all = TRUE)
     idx <- c(1, 12, 13, 14)
-    .h5write_spectra(sps[idx], h5f, group = grp, prune = TRUE)
-    res <- MSnbase:::.hdf5_read_spectra(fd[idx, ], h5f, fln)
+    md5 <- MSnbase:::.h5_write_spectra(sps[idx], h5f, group = grp, prune = TRUE)
+    res <- MSnbase:::.h5_read_spectra(fd[idx, ], h5f, md5, fln)
     res[[1]]@tic <- 0 # fData still contains the TIC, while the spectra has 0.
     expect_equal(unname(res), unname(sps[idx]))
     cont <- rhdf5::h5ls(h5f)
-    expect_equal(nrow(cont), length(idx) + 1)
+    expect_equal(nrow(cont), length(idx) + 2)
 })
 
 test_that("filterFile,Hdf5MSnExp works", {
@@ -153,15 +158,18 @@ test_that("filterFile,Hdf5MSnExp works", {
     expect_equal(fData(res), fd)
 })
 
-test_that("consolidate for Hdf5MSnExp objects works", {
+test_that("writeHdf5Data works", {
     ## Filter by retention time.
     sciex_flt <- filterRt(h5_sciex, rt = c(10, 100))
     sps <- spectra(sciex_flt)
     ## consolidate will update the hdf5 files, so, h5_sciex will fail!
     res <- MSnbase:::.consolidate(sciex_flt)
+    ##
+    expect_true(MSnbase:::.h5_check_md5(res))
+    expect_false(MSnbase:::.h5_check_md5(h5_sciex))
     expect_error(spectra(h5_sciex))
     cont <- rhdf5::h5ls(res@hdf5file[1])
-    expect_equal(nrow(cont), (length(sps) / 2) + 1)
+    expect_equal(nrow(cont), (length(sps) / 2) + 2)
 
     ## Doing some data manipulations on the subsetted data
     res_cent <- pickPeaks(smooth(res))
@@ -172,7 +180,11 @@ test_that("consolidate for Hdf5MSnExp objects works", {
         z
     })
     ## Consolidate with in-place replacement.
-    consolidate(res_cent)
+    md5_before <- res_cent@md5sum
+    writeHdf5Data(res_cent)
+    md5_after <- res_cent@md5sum
+    expect_true(all(md5_before != md5_after))
+
     # Don't have a processing queue because we replaced in-place
     expect_equal(length(res_cent@spectraProcessingQueue), 0)
     res_cent_sps <- spectra(res_cent)


### PR DESCRIPTION
- `updateHdf5MSnExp` function to *consolidate*/save any data changes back to the hdf5 files.
- `filterFile,Hdf5MSnExp` to ensure that also the `hdf5file` slot gets updated correctly.
- `convertToHdf5MSnExp` to convert an `OnDiskMSnExp` to a `Hdf5MSnExp` object (instead of `as`, since that does not support required additional arguments.
- unit tests.

