### PR TITLE
backendSplitByFile

### DIFF
--- a/R/Backend-class.R
+++ b/R/Backend-class.R
@@ -275,7 +275,7 @@ setGeneric(
 #' Subsetting could/should be done based on columns `"fileIdx"`, `"spIdx"`
 #' and/or `rownames(spectraData)`.
 #'
-#' @param x `Backend`
+#' @param object `Backend`
 #'
 #' @param spectraData `DataFrame` with the spectrum metadata of the spectra to
 #'     which the `object` should be subsetted.
@@ -298,6 +298,75 @@ setMethod("backendSubset", "Backend", function(object, spectraData) {
     fidx <- unique(spectraData$fileIdx)
     object@files <- object@files[fidx]
     object@modCount <- object@modCount[fidx]
+    validObject(object)
+    object
+})
+
+#' @description
+#'
+#' Split the `Backend` based on the provided `spectraData` data frame.
+#' Splitting could/should be done based on columns `"fileIdx"`.
+#'
+#' @param object `Backend`
+#'
+#' @param spectraData `DataFrame` with the spectrum metadata of the spectra to
+#'     which the `object` should be subsetted.
+#'
+#' @return A `list` of `Backend` classes.
+#'
+#' @author Sebastian Gibb
+#'
+#' @rdname hidden_aliases
+#'
+#' @noRd
+setGeneric(
+    "backendSplitByFile",
+    def = function(object, spectraData, ...)
+        standardGeneric("backendSplitByFile"),
+    valueClass = "list"
+)
+setMethod("backendSplitByFile", "Backend", function(object, spectraData, ...) {
+    lapply(
+        split(spectraData, spectraData$fileIdx),
+        backendSubset,
+        object = object
+    )
+})
+
+#' @description
+#'
+#' The reverse/undo function to `backendSplitByFile`.
+#'
+#' @param object `Backend`
+#'
+#' @param spectraData `DataFrame` with the spectrum metadata of the spectra to
+#'     which the `object` should be subsetted.
+#'
+#' @return A `Backend` class.
+#'
+#' @author Sebastian Gibb
+#'
+#' @rdname hidden_aliases
+#'
+#' @noRd
+setGeneric(
+    "backendSplitByFile<-",
+    def = function(object, spectraData, ..., value)
+        standardGeneric("backendSplitByFile<-"),
+    valueClass = "Backend"
+)
+setReplaceMethod(
+    "backendSplitByFile",
+    "Backend",
+    function(object, spectraData, ..., value) {
+    fidx <- unique(spectraData$fileIdx)
+    if (length(fidx) != length(value)) {
+        stop("Length of assignment is not the same as number of files.")
+    }
+    for (i in seq_along(value)) {
+        object@files[fidx[i]] <- value[[i]]@files
+        object@modCount[fidx[i]] <- value[[i]]@modCount
+    }
     validObject(object)
     object
 })

--- a/R/Backend-class.R
+++ b/R/Backend-class.R
@@ -359,7 +359,7 @@ setReplaceMethod(
     "backendSplitByFile",
     "Backend",
     function(object, spectraData, ..., value) {
-    fidx <- unique(spectraData$fileIdx)
+    fidx <- unique(sort.int(spectraData$fileIdx))
     if (length(fidx) != length(value)) {
         stop("Length of assignment is not the same as number of files.")
     }
@@ -398,40 +398,3 @@ setGeneric("backendUpdateMetadata", def = function(object, spectraData)
 setMethod("backendUpdateMetadata", "Backend", function(object, spectraData) {
     object
 })
-
-#' @description
-#'
-#' `backendApplyProcessingQueue` forces execution of all data manipulation steps
-#' in `queue` and writes the changes backe to the backend. The default
-#' implementation reads all spectra first, applies the queue (in parallel) and
-#' writes the spectra again to the backend.
-#'
-#' @param x `Backend`.
-#'
-#' @param spectraData `DataFrame` with the spectrum metadata.
-#'
-#' @param queue `list` with [ProcessingStep()] objects.
-#'
-#' @return A `Backend` class.
-#'
-#' @author Johannes Rainer
-#'
-#' @rdname hidden_aliases
-#'
-#' @noRd
-setGeneric("backendApplyProcessingQueue",
-           def = function(object, spectraData, queue, ..., BPPARAM = bpparam())
-               standardGeneric("backendApplyProcessingQueue"),
-           valueClass = "Backend")
-setMethod("backendApplyProcessingQueue", "Backend",
-          function(object, spectraData, queue, ..., BPPARAM = bpparam()) {
-              sps <- backendReadSpectra(object, spectraData)
-              object <- backendWriteSpectra(
-                  object,
-                  unlist(bplapply(sps, .apply_processing_queue, queue = queue,
-                                  BPPARAM = BPPARAM), use.names = FALSE,
-                         recursive = FALSE),
-                  spectraData)
-              validObject(object)
-              object
-          })

--- a/R/BackendHdf5-class.R
+++ b/R/BackendHdf5-class.R
@@ -292,19 +292,13 @@ setMethod("backendSubset", "BackendHdf5", function(object, spectraData) {
     callNextMethod()
 })
 
-setMethod("backendApplyProcessingQueue", "BackendHdf5",
-          function(object, spectraData, queue, ..., BPPARAM = bpparam()) {
-              cnts <- bplapply(split(spectraData, spectraData$fileIdx),
-                               function(z, bknd, queue) {
-                                   res <- backendWriteSpectra(
-                                       bknd, .apply_processing_queue(
-                                                 backendReadSpectra(bknd, z),
-                                                 queue),
-                                       z)
-                                   res@modCount[z$fileIdx[1]]
-                               }, bknd = object, queue = queue,
-                               BPPARAM = BPPARAM)
-              object@modCount <- unlist(cnts, use.names = FALSE)
-              validObject(object)
-              object
-          })
+setReplaceMethod(
+    "backendSplitByFile",
+    "BackendHdf5",
+    function(object, spectraData, ..., value) {
+    fidx <- unique(sort.int(spectraData$fileIdx))
+    for (i in seq(along=value)) {
+        object@h5files[fidx[i]] <- value[[i]]@h5files
+    }
+    callNextMethod()
+})

--- a/R/BackendMemory-class.R
+++ b/R/BackendMemory-class.R
@@ -45,6 +45,14 @@ setMethod("backendSubset", "BackendMemory", function(object, spectraData) {
     })
     callNextMethod()
 })
+setReplaceMethod("backendSplitByFile", "BackendMemory", function(object, spectraData,
+                                                           ..., value) {
+    rn <- split(rownames(spectraData), spectraData$fileIdx)
+    for (i in seq(along=value)) {
+        object@spectra[rn[[i]]] <- value[[i]]@spectra
+    }
+    callNextMethod()
+})
 
 #' @rdname hidden_aliases
 setMethod(
@@ -90,7 +98,7 @@ setMethod(
     definition = function(object, spectra, spectraData, ...,
                           BPPARAM = bpparam()) {
         object@spectra[rownames(spectraData)] <- spectra
-        idx <- unique(vapply(spectra, fromFile, integer(1)))
+        idx <- unique(vapply(spectra, fromFile, integer(1L)))
         object@modCount[idx] <- object@modCount[idx] + 1L
         validObject(object)
         object

--- a/R/BackendMemory-class.R
+++ b/R/BackendMemory-class.R
@@ -39,10 +39,14 @@ BackendMemory <- function() { new("BackendMemory") }
 setMethod("backendSubset", "BackendMemory", function(object, spectraData) {
     fidx <- unique(spectraData$fileIdx)
     ## Update also `@fromFile` in the spectra.
-    object@spectra <- lapply(object@spectra[rownames(spectraData)], function(z) {
-        z@fromFile <- match(z@fromFile, fidx)
-        z
-    })
+    object@spectra <- lapply(
+        object@spectra[rownames(spectraData)],
+        function(s) {
+            if (!is.null(s))
+                s@fromFile <- match(s@fromFile, fidx)
+            s
+        }
+    )
     callNextMethod()
 })
 

--- a/R/BackendMemory-class.R
+++ b/R/BackendMemory-class.R
@@ -45,11 +45,17 @@ setMethod("backendSubset", "BackendMemory", function(object, spectraData) {
     })
     callNextMethod()
 })
-setReplaceMethod("backendSplitByFile", "BackendMemory", function(object, spectraData,
-                                                           ..., value) {
+
+#' @rdname hidden_aliases
+setReplaceMethod(
+    "backendSplitByFile",
+    "BackendMemory",
+    function(object, spectraData, ..., value) {
     rn <- split(rownames(spectraData), spectraData$fileIdx)
+    fidx <- as.integer(sort.int(unique(spectraData$fileIdx)))
     for (i in seq(along=value)) {
-        object@spectra[rn[[i]]] <- value[[i]]@spectra
+        object@spectra[rn[[i]]] <-
+            lapply(value[[i]]@spectra, function(s){ s@fromFile <- fidx[i]; s })
     }
     callNextMethod()
 })

--- a/R/BackendMzR-class.R
+++ b/R/BackendMzR-class.R
@@ -16,6 +16,18 @@ setMethod("backendReadSpectra", "BackendMzR", function(object,
                       USE.NAMES = FALSE), recursive = FALSE)
 })
 
+#' @rdname hidden_aliases
+setMethod(
+    "backendWriteSpectra",
+    "BackendMzR",
+    function(object, spectra, spectraData) {
+        if (isMSnbaseVerbose()) {
+            message("Can not make changes to spectrum data persistent: ",
+                    "'BackendMzR' is read-only.")
+        }
+    object
+})
+
 #' @rdname Backend
 BackendMzR <- function() {
     new("BackendMzR")
@@ -49,11 +61,3 @@ BackendMzR <- function() {
         mzi <- list(mzi)
     .spectra_from_data(mzi, spectraData)
 }
-
-setMethod("backendApplyProcessingQueue", "BackendMzR",
-          function(object, spectraData, queue, ..., BPPARAM = bpparam()) {
-              if (isMSnbaseVerbose())
-                  message("Can not make changes to spectrum data persistent: ",
-                          "BackendMzR is read-only.")
-              object
-          })

--- a/R/MSnExperiment-class.R
+++ b/R/MSnExperiment-class.R
@@ -503,8 +503,9 @@ setMethod(
     backend <- backendInitialize(backend, fileNames(object), object@spectraData,
                                  ...)
     ## update fileIdx, useful to split src backends across cores
-    spd <- lapply(split(object@spectraData, object@spectraData$fileIdx),
-                  function(s) { s$fileIdx <- 1L; s })
+    spd <- object@spectraData
+    spd$fileIdx <- 1L
+    spd <- split(spd, object@spectraData$fileIdx)
 
     backendSplitByFile(backend, object@spectraData) <-
         bpmapply(function(dst, src, spd, queue) {
@@ -544,8 +545,9 @@ applyProcessingQueue <- function(x, BPPARAM = bpparam()) {
             stop(isOK)
 
         ## update fileIdx, useful to split src backends across cores
-        spd <- lapply(split(x@spectraData, x@spectraData$fileIdx),
-                      function(s) { s$fileIdx <- 1L; s })
+        spd <- object@spectraData
+        spd$fileIdx <- 1L
+        spd <- split(spd, object@spectraData$fileIdx)
 
         mod_c <- x@backend@modCount
 

--- a/R/MSnExperiment-class.R
+++ b/R/MSnExperiment-class.R
@@ -545,9 +545,9 @@ applyProcessingQueue <- function(x, BPPARAM = bpparam()) {
             stop(isOK)
 
         ## update fileIdx, useful to split src backends across cores
-        spd <- object@spectraData
+        spd <- x@spectraData
         spd$fileIdx <- 1L
-        spd <- split(spd, object@spectraData$fileIdx)
+        spd <- split(spd, x@spectraData$fileIdx)
 
         mod_c <- x@backend@modCount
 

--- a/R/MSnExperiment-class.R
+++ b/R/MSnExperiment-class.R
@@ -610,9 +610,14 @@ addProcessingStep <- function(object, FUN, ...) {
     object
 }
 
+#' @rdname MSnExperiment
+#' @name coerce,MSnExperiment,list-method
 setAs("MSnExperiment", "list", function(from) {
     spectrapply(from)
 })
+
+#' @rdname MSnExperiment
+#' @name coerce,MSnExperiment,List-method
 setAs("MSnExperiment", "List", function(from) {
     List(spectrapply(from))
 })

--- a/man/MSnExperiment.Rd
+++ b/man/MSnExperiment.Rd
@@ -12,6 +12,8 @@
 \alias{setBackend}
 \alias{applyProcessingQueue}
 \alias{spectrapply,MSnExperiment-method}
+\alias{coerce,MSnExperiment,list-method}
+\alias{coerce,MSnExperiment,List-method}
 \alias{featureData,MSnExperiment-method}
 \alias{featureData<-,MSnExperiment,ANY-method}
 \alias{spectraData,MSnExperiment-method}

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -9,16 +9,17 @@
 \alias{fileNames,Backend-method}
 \alias{show,BackendHdf5-method}
 \alias{backendSubset,BackendMemory-method}
+\alias{backendSplitByFile<-,BackendMemory-method}
 \alias{backendInitialize,BackendMemory-method}
 \alias{backendImportData,BackendMemory-method}
 \alias{backendReadSpectra,BackendMemory-method}
 \alias{backendWriteSpectra,BackendMemory-method}
 \alias{backendUpdateMetadata,BackendMemory-method}
 \alias{backendReadSpectra,BackendMzR-method}
+\alias{backendWriteSpectra,BackendMzR-method}
 \alias{show,MSnExperiment-method}
 \alias{setBackend,MSnExperiment,Backend-method}
 \alias{setBackend,MSnExperiment,BackendMzR-method}
-\alias{setBackend,MSnExperiment,BackendHdf5-method}
 \title{Internal page for hidden aliases}
 \usage{
 \S4method{show}{Backend}(object)
@@ -28,6 +29,9 @@
 \S4method{show}{BackendHdf5}(object)
 
 \S4method{backendSubset}{BackendMemory}(object, spectraData)
+
+\S4method{backendSplitByFile}{BackendMemory}(object, spectraData,
+  ...) <- value
 
 \S4method{backendInitialize}{BackendMemory}(object, files, spectraData,
   ..., BPPARAM = bpparam())
@@ -46,15 +50,14 @@
 \S4method{backendReadSpectra}{BackendMzR}(object, spectraData,
   processingQueue = list(), ...)
 
+\S4method{backendWriteSpectra}{BackendMzR}(object, spectra, spectraData)
+
 \S4method{show}{MSnExperiment}(object)
 
 \S4method{setBackend}{MSnExperiment,Backend}(object, backend, ...,
   BPPARAM = bpparam())
 
 \S4method{setBackend}{MSnExperiment,BackendMzR}(object, backend, ...,
-  BPPARAM = bpparam())
-
-\S4method{setBackend}{MSnExperiment,BackendHdf5}(object, backend, ...,
   BPPARAM = bpparam())
 }
 \arguments{

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -42,6 +42,6 @@ sciex <- readMSData(sf, mode = "onDisk")
 sciex_inmem <- readMSnExperiment(sf, backend = BackendMemory())
 sciex_mzr <- readMSnExperiment(sf, backend = BackendMzR())
 sciex_h5 <- readMSnExperiment(sf, backend = BackendHdf5(),
-                              path = paste0(tempdir(), "/sciex_h5/"))
+                              path = file.path(tempdir(), "sciex_h5"))
 
 test_check("MSnbase")

--- a/tests/testthat/test_Backend.R
+++ b/tests/testthat/test_Backend.R
@@ -51,11 +51,24 @@ test_that("backendSubset,Backend works", {
     expect_equal(be, backendSubset(be, spd))
 })
 
-test_that("backendApplyProcessingQueue,Backend works", {
-    tmp <- sciex_inmem[c(13, 17, 33, 1013, 1017)]
-    be <- tmp@backend
-    the_q <- list(ProcessingStep(removePeaks, list(t = 1000)))
-    res <- backendApplyProcessingQueue(be, tmp@spectraData, the_q)
-    expect_equal(res@spectra, lapply(be@spectra, removePeaks, t = 1000))
-    expect_equal(res@modCount, c(1L, 1L))
+test_that("backendSplitByFile,Backend works", {
+    b <- BackendMzR()
+    b@files <- c("a", "b", "c")
+    b@modCount <- rep(0L, 3L)
+    spd <- DataFrame(fileIdx = c(3, 3, 1, 1, 2, 1))
+    res <- backendSplitByFile(b, spd)
+    bl <- BackendMzR()
+    bl@files <- "a"
+    bl@modCount <- 0L
+    l <- list("1"=bl, "2"=bl, "3"=bl)
+    l[[2]]@files <- "b"
+    l[[3]]@files <- "c"
+    expect_equal(backendSplitByFile(b, spd), l)
+    r <- b
+    r@files[1] <- "d"
+    r@modCount[1L] <- 1L
+    l[[1]]@files <- "d"
+    l[[1]]@modCount <- 1L
+    backendSplitByFile(b, spd) <- l
+    expect_equal(b, r)
 })

--- a/tests/testthat/test_BackendMzR.R
+++ b/tests/testthat/test_BackendMzR.R
@@ -27,14 +27,3 @@ test_that("backendReadSpectra,BackendMzR works", {
     expect_true(all(vapply(res, is, "Spectrum", FUN.VALUE = logical(1))))
     expect_equal(res, sciex_spectra[spd$fileIdx == 2])
 })
-
-test_that("backendApplyProcessingQueue,BackendMzR works", {
-    be <- sciex_mzr@backend
-    spd <- sciex_mzr@spectraData[c(13, 15, 33, 113, 117, 167), ]
-    the_q <- list(ProcessingStep("removePeaks", list(t = 5000)))
-    v <- isMSnbaseVerbose()
-    setMSnbaseVerbose(TRUE)
-    expect_message(res <- backendApplyProcessingQueue(be, spd, queue = the_q))
-    expect_equal(res@modCount, c(0L, 0L))
-    setMSnbaseVerbose(v)
-})


### PR DESCRIPTION
This PR introduces `backendSplitByFile` and `backendSplitByFile<-` to replace the multiple versions of `setBackend`, `backendApplyProcessingQueue` as suggested in https://github.com/lgatto/MSnbase/pull/443#pullrequestreview-207983080. 

Now there is no need for multiple `setBackend` methods anymore (but I kept one for `BackendMzR` to produce a meaningful error message instead of silently doing nothing).

There is one aspect I don't like in the current implementation. Because I use `backendSplitByFile` to split the backends across cores in a parallel approach (without duplicating the whole list of spectra for e.g. `BackendMemory`) all file indices that are used in `backendReadSpectra` are `1` so we have to updated them with such stupid approach:
```r
spd <- object@spectraData
spd$fileIdx <- 1L
spd <- split(spd, object@spectraData$fileIdx)
```

Any better idea?