### PR TITLE
Remove backendImportData

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,10 @@ jobs:
       install: skip
       name: "examples"
     - r_build_args: --no-build-vignettes --no-manual
-      r_check_args: --as-cran --no-build-vignettes --no-vignettes --no-manual --no-codoc --no-examples
       install: skip
       before_script: rm -rf vignettes
+      script:
+        - travis_wait 20 R CMD check "${PKG_TARBALL}" --as-cran --no-build-vignettes --no-vignettes --no-manual --no-codoc --no-examples
       name: "tests"
     - r_build_args:
       r_check_args: --as-cran --no-build-vignettes --no-codoc --no-examples --no-tests

--- a/R/Backend-class.R
+++ b/R/Backend-class.R
@@ -227,15 +227,17 @@ setGeneric(
 #' It *MUST* be reimplemented by all backends!
 #'
 #' @inheritParams backendReadSpectra
-#' @param spectra A list of [Spectrum-class] objects that should be written to
+#' @param spectra A `list` of [Spectrum-class] objects that should be written to
 #' the backend.
+#' @param updateModCount `logical`, should the `@modCount` be incremented? Only
+#' set to `FALSE` if you know what you are doing (e.g. in `setBackend`).
 #' @return A [Backend-class] derivate.
 #' @family Backend generics
 #' @author Sebastian Gibb \email{mail@@sebastiangibb.de}
 #' @noRd
 setGeneric(
     "backendWriteSpectra",
-    def = function(object, spectra, spectraData, ...)
+    def = function(object, spectra, spectraData, updateModCount = TRUE, ...)
         standardGeneric("backendWriteSpectra"),
     valueClass = "Backend"
 )

--- a/R/Backend-class.R
+++ b/R/Backend-class.R
@@ -75,7 +75,6 @@ NULL
 #' It may also provide methods for:
 #'
 #' - [backendInitialize()] to setup the backend (create files, tables, ...).
-#' - [backendImportData()] to initial import data from source *mzML* files.
 #' - [backendDeepCopy()] to create a copy of the backend with associated files.
 #'
 #' @name Backend
@@ -166,34 +165,6 @@ setMethod(
     object@files <- files
     object@modCount <- integer(length(files))
     validObject(object)
-    object
-})
-
-#' Import spectra data into a backend
-#'
-#' This generic is used to import spectra data into a backend.
-#'
-#' It should be only reimplemented if the backend is created from scratch
-#' e.g. for *HDF5* the content of the .mzML files is imported into .h5 files.
-#' It must not be reimplemented for the .mzML backend.
-#'
-#' @inheritParams backendInitialize
-#' @param BPPARAM Should parallel processing be used? See
-#' [BiocParallel::bpparam()].
-#' @return A [Backend-class] derivate.
-#' @family Backend generics
-#' @author Sebastian Gibb \email{mail@@sebastiangibb.de}
-#' @noRd
-setGeneric(
-    "backendImportData",
-    def = function(object, spectraData, ..., BPPARAM = bpparam())
-        standardGeneric("backendImportData"),
-    valueClass = "Backend"
-)
-setMethod(
-    "backendImportData",
-    signature = "Backend",
-    definition = function(object, spectraData, ..., BPPARAM = bpparam()) {
     object
 })
 

--- a/R/BackendHdf5-class.R
+++ b/R/BackendHdf5-class.R
@@ -230,19 +230,20 @@ setMethod("backendReadSpectra", "BackendHdf5", function(object, spectraData,
 }
 
 setMethod("backendWriteSpectra", "BackendHdf5", function(object, spectra,
-                                                         spectraData) {
+                                                         spectraData,
+                                                         updateModCount, ...) {
     file_f <- factor(spectraData$fileIdx, levels = unique(spectraData$fileIdx))
     idx <- as.integer(levels(file_f))
     fls <- object@h5files[idx]
-    modCount <- object@modCount[idx] + 1L
+    if (updateModCount)
+        object@modCount[idx] <- object@modCount[idx] + 1L
     if (length(fls) == 1)
-        .h5_write_spectra(spectra, spectraData, fls, modCount)
+        .h5_write_spectra(spectra, spectraData, fls, object@modCount[idx])
     else
         unlist(mapply(split(spectra, file_f), split(spectraData, file_f),
-                            fls, modCount, FUN = .h5_write_spectra,
+                            fls, object@modCount[idx], FUN = .h5_write_spectra,
                             SIMPLIFY = FALSE, USE.NAMES = FALSE),
                       recursive = FALSE)
-    object@modCount[idx] <- modCount
     object
 })
 

--- a/R/BackendHdf5-class.R
+++ b/R/BackendHdf5-class.R
@@ -86,26 +86,6 @@ setMethod("backendInitialize", "BackendHdf5", function(object, files,
     callNextMethod()
 })
 
-#' Import the data from the raw MS files and store them to the hdf5 files.
-#'
-#' @inheritParams backendInitialize
-#'
-#' @return `BackendHdf5`
-#'
-#' @author Johannes Rainer
-#'
-#' @md
-#'
-#' @noRd
-setMethod("backendImportData", "BackendHdf5", function(object, spectraData,
-                                                       ...,
-                                                       BPPARAM = bpparam()) {
-    bpmapply(fileNames(object), object@h5files, FUN = .serialize_msfile_to_hdf5,
-             BPPARAM = BPPARAM)
-    validObject(object)
-    object
-})
-
 #' Create a deep copy (means also copying the hdf5 files).
 #'
 #' @inheritParams backendInitialize
@@ -121,27 +101,6 @@ setMethod(
     definition = function(object, ...) {
     stop("Not implemented yet!")
 })
-
-#' Write the content of a single mzML/etc file to an h5file. We're using the
-#' spectrum index in the file as data set ID.
-#'
-#' @author Johannes Rainer, Sebastian Gibb
-#'
-#' @noRd
-.serialize_msfile_to_hdf5 <- function(file, h5file) {
-    h5 <- H5Fopen(h5file)
-    on.exit(H5Fclose(h5))
-    comp_level <- .hdf5_compression_level()
-    fh <- openMSfile(file)
-    hdr <- header(fh)
-    pks <- peaks(fh)
-    close(fh)
-    spids <- paste0("/spectra/", seq_along(pks))
-    for (i in seq_along(pks)) {
-        h5write(pks[[i]], h5, spids[i], level = comp_level)
-    }
-    h5write(0L, h5, "/modification/counter", level = comp_level)
-}
 
 setMethod("backendReadSpectra", "BackendHdf5", function(object, spectraData,
                                                         ...) {

--- a/R/BackendMemory-class.R
+++ b/R/BackendMemory-class.R
@@ -79,22 +79,6 @@ setMethod(
 
 #' @rdname hidden_aliases
 setMethod(
-    "backendImportData",
-    signature = "BackendMemory",
-    definition = function(object, spectraData, ..., BPPARAM = bpparam()) {
-
-    spd <- split(spectraData, spectraData$fileIdx)
-
-    split(object@spectra, spectraData$fileIdx) <- bpmapply(
-        .spectra_from_file_mzR, file = object@files, spectraData = spd,
-        USE.NAMES = FALSE, SIMPLIFY = FALSE, BPPARAM = BPPARAM
-    )
-    validObject(object)
-    object
-})
-
-#' @rdname hidden_aliases
-setMethod(
     "backendReadSpectra",
     signature = "BackendMemory",
     definition = function(object, spectraData, ..., BPPARAM = bpparam()) {

--- a/R/BackendMemory-class.R
+++ b/R/BackendMemory-class.R
@@ -89,11 +89,12 @@ setMethod(
 setMethod(
     "backendWriteSpectra",
     signature = "BackendMemory",
-    definition = function(object, spectra, spectraData, ...,
-                          BPPARAM = bpparam()) {
+    definition = function(object, spectra, spectraData, updateModCount, ...) {
         object@spectra[rownames(spectraData)] <- spectra
-        idx <- unique(vapply(spectra, fromFile, integer(1L)))
-        object@modCount[idx] <- object@modCount[idx] + 1L
+        if (updateModCount) {
+            idx <- unique(vapply(spectra, fromFile, integer(1L)))
+            object@modCount[idx] <- object@modCount[idx] + 1L
+        }
         validObject(object)
         object
 })

--- a/R/MSnExperiment-class.R
+++ b/R/MSnExperiment-class.R
@@ -487,7 +487,11 @@ readMSnExperiment <- function(file, sampleData, backend = BackendMzR(),
         metadata = metadata,
         processing = paste0("Data loaded [", date(), "]")
     )
-    setBackend(msnexp, backend, ..., BPPARAM = BPPARAM)
+
+    if (!inherits(backend, "BackendMzR"))
+        msnexp <- setBackend(msnexp, backend, ..., BPPARAM = BPPARAM)
+
+    msnexp
 }
 
 #' @rdname MSnExperiment
@@ -505,9 +509,14 @@ setMethod(
     spd$fileIdx <- 1L
     spd <- split(spd, object@spectraData$fileIdx)
 
+    ## keep current modCount
+    backend@modCount <- object@backend@modCount
+
     backendSplitByFile(backend, object@spectraData) <-
         bpmapply(function(dst, src, spd, queue) {
-            backendWriteSpectra(dst, backendReadSpectra(src, spd), spd)
+            backendWriteSpectra(
+                dst, backendReadSpectra(src, spd), spd, updateModCount=FALSE
+            )
         },
         dst = backendSplitByFile(backend, object@spectraData),
         src = backendSplitByFile(object@backend, object@spectraData),
@@ -515,6 +524,9 @@ setMethod(
         SIMPLIFY = FALSE, USE.NAMES = FALSE, BPPARAM = BPPARAM)
 
     object@backend <- backend
+    object@processing <- c(object@processing,
+                           paste0("Backend set to '", class(backend),
+                                  "' [", date(), "]"))
     validObject(object)
     object
 })
@@ -524,11 +536,13 @@ setMethod(
     "setBackend",
     c("MSnExperiment", "BackendMzR"),
     function(object, backend, ..., BPPARAM = bpparam()) {
-    if (any(object@backend@modCount > 0))
+    if (any(object@backend@modCount))
         stop("Can not change backend to 'BackendMzR' because the ",
              "data was changed.")
     object@backend <- backendInitialize(backend, fileNames(object),
                                         object@spectraData, ...)
+    object@processing <- c(object@processing,
+                           paste0("Backend set to 'BackendMzR' [", date(), "]"))
     validObject(object)
     object
 })

--- a/R/MSnExperiment-class.R
+++ b/R/MSnExperiment-class.R
@@ -477,19 +477,17 @@ readMSnExperiment <- function(file, sampleData, backend = BackendMzR(),
         hdr[order(hdr$acquisitionNum), ]
     }
     spectraData <- DataFrame(
-        do.call(rbind, bplapply(file, .read_file, files=file,
-                                smoothed=smoothed, BPPARAM=BPPARAM)))
-    backend <- backendInitialize(backend, file, spectraData, ...,
-                                 BPPARAM=BPPARAM)
-    backend <- backendImportData(backend, spectraData, BPPARAM=BPPARAM)
-    new("MSnExperiment",
-        backend = backend,
+        do.call(rbind, bplapply(file, .read_file, files = file,
+                                smoothed = smoothed, BPPARAM = BPPARAM)))
+    msnexp <- new("MSnExperiment",
+        backend = backendInitialize(BackendMzR(), file),
         sampleData = sampleData,
         spectraData = spectraData,
         processingQueue = list(),
         metadata = metadata,
         processing = paste0("Data loaded [", date(), "]")
     )
+    setBackend(msnexp, backend, ..., BPPARAM = BPPARAM)
 }
 
 #' @rdname MSnExperiment

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -11,7 +11,6 @@
 \alias{backendSubset,BackendMemory-method}
 \alias{backendSplitByFile<-,BackendMemory-method}
 \alias{backendInitialize,BackendMemory-method}
-\alias{backendImportData,BackendMemory-method}
 \alias{backendReadSpectra,BackendMemory-method}
 \alias{backendWriteSpectra,BackendMemory-method}
 \alias{backendUpdateMetadata,BackendMemory-method}
@@ -35,9 +34,6 @@
 
 \S4method{backendInitialize}{BackendMemory}(object, files, spectraData,
   ..., BPPARAM = bpparam())
-
-\S4method{backendImportData}{BackendMemory}(object, spectraData, ...,
-  BPPARAM = bpparam())
 
 \S4method{backendReadSpectra}{BackendMemory}(object, spectraData, ...,
   BPPARAM = bpparam())

--- a/man/hidden_aliases.Rd
+++ b/man/hidden_aliases.Rd
@@ -39,7 +39,7 @@
   BPPARAM = bpparam())
 
 \S4method{backendWriteSpectra}{BackendMemory}(object, spectra, spectraData,
-  ..., BPPARAM = bpparam())
+  updateModCount = TRUE, ...)
 
 \S4method{backendUpdateMetadata}{BackendMemory}(object, spectraData)
 

--- a/tests/testthat/test_BackendHdf5.R
+++ b/tests/testthat/test_BackendHdf5.R
@@ -87,7 +87,7 @@ test_that(".h5_write_spectra, and backendWriteSpectra,BackendHdf5 work", {
     expect_equal(sps[spd$fileIdx == 1], res)
     expect_error(backendReadSpectra(be, spd[spd$fileIdx == 2, ]),
                  "The data .* have changed")
-    be@modCount[2] <- 2L
+    be@modCount[2] <- 1L
     res <- backendReadSpectra(be, spd[idx, ])
     expect_equal(res, sps[idx])
 

--- a/tests/testthat/test_BackendHdf5.R
+++ b/tests/testthat/test_BackendHdf5.R
@@ -87,7 +87,7 @@ test_that(".h5_write_spectra, and backendWriteSpectra,BackendHdf5 work", {
     expect_equal(sps[spd$fileIdx == 1], res)
     expect_error(backendReadSpectra(be, spd[spd$fileIdx == 2, ]),
                  "The data .* have changed")
-    be@modCount[2] <- 1L
+    be@modCount[2] <- 2L
     res <- backendReadSpectra(be, spd[idx, ])
     expect_equal(res, sps[idx])
 

--- a/tests/testthat/test_BackendHdf5.R
+++ b/tests/testthat/test_BackendHdf5.R
@@ -18,37 +18,6 @@ test_that("BackendHdf5 works", {
     expect_error(validObject(tst))
 })
 
-test_that("backendInitialize and backendImportData,BackendHdf5 work", {
-    tst <- BackendHdf5()
-    dr <- tempdir()
-    res <- backendInitialize(tst, files = sf, path = dr)
-    expect_equal(length(res@h5files), 2)
-    expect_true(all(file.exists(res@h5files)))
-    expect_error(backendInitialize(tst, files = sf, path = dr))
-    expect_true(validObject(res))
-    expect_identical(res@modCount, c(0L, 0L))
-    show(res)
-
-    ## backendImportData
-    spdata <- sciex_mzr@spectraData
-    res <- backendImportData(res, spdata)
-    cont <- rhdf5::h5ls(res@h5files[1])
-    expect_equal(sum(spdata$fileIdx == 1) + 3, nrow(cont))
-    cont <- rhdf5::h5ls(res@h5files[2])
-    expect_equal(sum(spdata$fileIdx == 2) + 3, nrow(cont))
-})
-
-test_that(".serialize_msfile_to_hdf5 works", {
-    h5file <- tempfile()
-    h5 <- rhdf5::H5Fcreate(h5file)
-    rhdf5::h5createGroup(h5, "spectra")
-    rhdf5::h5createGroup(h5, "modification")
-    rhdf5::H5Fclose(h5)
-    .serialize_msfile_to_hdf5(fileNames(sciex)[1], h5file)
-    cont <- rhdf5::h5ls(h5file)
-    expect_equal(nrow(cont), sum(fromFile(sciex) == 1) + 3)
-})
-
 test_that(".h5_read_bare works", {
     expect_error(.h5_read_bare())
     expect_error(.h5_read_bare("5"))

--- a/tests/testthat/test_BackendMemory.R
+++ b/tests/testthat/test_BackendMemory.R
@@ -108,43 +108,6 @@ test_that("backendInitialize", {
     expect_equal(names(b@spectra), rownames(spd))
 })
 
-test_that("backendImportData", {
-    f <- system.file(
-        file.path("microtofq", c("MM8.mzML", "MM14.mzML")),
-        package="msdata"
-    )
-    nn <- c(4, 3)
-    n <- sum(nn)
-    spd <-  DataFrame(
-        fileIdx=rep(1:2, nn),
-        spIdx=c(seq_len(nn[1]), seq_len(nn[2])),
-        smoothed=FALSE,
-        row.names=paste0(rep(c("F1", "F2"), nn),
-                         ".S", c(seq_len(nn[1]), seq_len(nn[2])))
-    )
-    hdr <- pks <- vector(mode="list", length=length(f))
-
-    for (i in seq(along=f)) {
-        fh <- mzR::openMSfile(f[i])
-        j <- seq_len(nn[i])
-        hdr[[i]] <- header(fh, j)
-        pks[[i]] <- peaks(fh, j)
-        close(fh)
-    }
-    hdr <- do.call(rbind, hdr)
-    pks <- unlist(pks, recursive=FALSE)
-    spd <- cbind(spd, hdr)
-
-    b <- backendInitialize(BackendMemory(), files=f, spectraData=spd)
-    b <- backendImportData(b, spectraData=spd, BPPARAM=SerialParam())
-    expect_length(b@spectra, n)
-    expect_equal(names(b@spectra), rownames(spd))
-    expect_equal(lapply(b@spectra, mz),
-                 setNames(lapply(pks, function(p)p[,1]), rownames(spd)))
-    expect_equal(lapply(b@spectra, intensity),
-                 setNames(lapply(pks, function(p)p[,2]), rownames(spd)))
-})
-
 test_that("backendReadSpectra/backendWriteSpectra", {
     spd <- DataFrame(fileIdx=c(1, 1, 2), spIdx=1:3,
                      row.names=c("F1.S1", "F1.S2", "F2.S3"))

--- a/tests/testthat/test_MSnExperiment-class.R
+++ b/tests/testthat/test_MSnExperiment-class.R
@@ -311,10 +311,10 @@ test_that("applyProcessingQueue works", {
     idx <- c(13, 15, 33, 89, 113, 117, 167)
     mse_mem <- mse_mem[idx]
     mse_mem <- removePeaks(mse_mem, t = 5000)
-    expect_equal(mse_mem@backend@modCount, c(1L, 1L))
+    expect_equal(mse_mem@backend@modCount, c(0L, 0L))
     expect_equal(length(mse_mem@processingQueue), 1L)
     mse_mem <- applyProcessingQueue(mse_mem)
-    expect_equal(mse_mem@backend@modCount, c(2L, 2L))
+    expect_equal(mse_mem@backend@modCount, c(1L, 1L))
     expect_true(length(mse_mem@processingQueue) == 0)
     expect_equal(as(mse_mem, "list"), lapply(sps[idx], removePeaks, t = 5000))
     ## Hdf5 backend
@@ -322,13 +322,13 @@ test_that("applyProcessingQueue works", {
                                 path = paste0(tempdir(), "/apq"))
     mse_h5 <- mse_h5[idx]
     sps <- spectrapply(mse_h5)
-    expect_equal(mse_h5@backend@modCount, c(1L, 1L))
+    expect_equal(mse_h5@backend@modCount, c(0L, 0L))
     expect_equal(length(mse_h5@processingQueue), 0L)
     mse_h5 <- removePeaks(mse_h5, t = 5000)
-    expect_equal(mse_h5@backend@modCount, c(1L, 1L))
+    expect_equal(mse_h5@backend@modCount, c(0L, 0L))
     expect_equal(length(mse_h5@processingQueue), 1L)
     mse_h5 <- applyProcessingQueue(mse_h5)
-    expect_equal(mse_h5@backend@modCount, c(2L, 2L))
+    expect_equal(mse_h5@backend@modCount, c(1L, 1L))
     expect_equal(length(mse_h5@processingQueue), 0L)
     expect_equal(spectrapply(mse_h5, ionCount),
                  lapply(sps, function(z) ionCount(removePeaks(z, t = 5000))))

--- a/tests/testthat/test_MSnExperiment-class.R
+++ b/tests/testthat/test_MSnExperiment-class.R
@@ -311,10 +311,10 @@ test_that("applyProcessingQueue works", {
     idx <- c(13, 15, 33, 89, 113, 117, 167)
     mse_mem <- mse_mem[idx]
     mse_mem <- removePeaks(mse_mem, t = 5000)
-    expect_equal(mse_mem@backend@modCount, c(0L, 0L))
+    expect_equal(mse_mem@backend@modCount, c(1L, 1L))
     expect_equal(length(mse_mem@processingQueue), 1L)
     mse_mem <- applyProcessingQueue(mse_mem)
-    expect_equal(mse_mem@backend@modCount, c(1L, 1L))
+    expect_equal(mse_mem@backend@modCount, c(2L, 2L))
     expect_true(length(mse_mem@processingQueue) == 0)
     expect_equal(as(mse_mem, "list"), lapply(sps[idx], removePeaks, t = 5000))
     ## Hdf5 backend
@@ -322,13 +322,13 @@ test_that("applyProcessingQueue works", {
                                 path = paste0(tempdir(), "/apq"))
     mse_h5 <- mse_h5[idx]
     sps <- spectrapply(mse_h5)
-    expect_equal(mse_h5@backend@modCount, c(0L, 0L))
+    expect_equal(mse_h5@backend@modCount, c(1L, 1L))
     expect_equal(length(mse_h5@processingQueue), 0L)
     mse_h5 <- removePeaks(mse_h5, t = 5000)
-    expect_equal(mse_h5@backend@modCount, c(0L, 0L))
+    expect_equal(mse_h5@backend@modCount, c(1L, 1L))
     expect_equal(length(mse_h5@processingQueue), 1L)
     mse_h5 <- applyProcessingQueue(mse_h5)
-    expect_equal(mse_h5@backend@modCount, c(1L, 1L))
+    expect_equal(mse_h5@backend@modCount, c(2L, 2L))
     expect_equal(length(mse_h5@processingQueue), 0L)
     expect_equal(spectrapply(mse_h5, ionCount),
                  lapply(sps, function(z) ionCount(removePeaks(z, t = 5000))))


### PR DESCRIPTION
In https://github.com/lgatto/MSnbase/pull/441#issuecomment-463136543 @jotsetung mentioned that he
> would not mix using the backend to store the data and backend to be used as a data importer. 

This PR suggests just that. Now we have `setBackend` that allows switching backends. `readMSnExperiment` uses always `BackendMzR` to generate the `MSnExperiment`. Before it is returned we call `setBackend` and switch the backend to the one the user asked for.
This greatly reduce code complexity and lines without loosing anything.

There is only one problem: `setBackend` uses `backendWriteSpectra` which increments the `@modCount` by one so `setBackend(..., BackendMzR())` fails in the current implementation (that is the reason for the one failing unit test). IMHO we have two possible solutions:
1. Allow a `@modCount <= 1` in `setBackend,MSnExperiment,BackendMzR`.
2. Decrement the `@modCount` by one in `setBackend`.

I would vote for the first solution.

What do you think?