### PR TITLE
Add methods for working with isolationWindows (#458) and fix issue #459

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.9.4
+Version: 2.9.5
 Description: MSnbase provides infrastructure for manipulation,
 	     processing and visualisation of mass spectrometry and
 	     proteomics data, ranging from raw to quantitative and
@@ -47,7 +47,8 @@ Authors@R: c(person(given = "Laurent", family = "Gatto",
 		    role = "ctb"),
 	     person(given = "Johannes", family = "Rainer",
 		    email = "Johannes.Rainer@eurac.edu",
-		    role = c("aut", "cre")),
+		    role = c("aut", "cre"),
+		    comment = c(ORCID = "0000-0002-6977-7147")),
 	     person(given = "Sebastian", family = "Gibb",
 		    email = "mail@sebastiangibb.de",
 		    role = c("aut", "cre")))
@@ -62,7 +63,7 @@ Depends:
     methods,
     BiocGenerics (>= 0.7.1),
     Biobase (>= 2.15.2),
-    mzR (>= 2.15.1),
+    mzR (>= 2.17.3),
     S4Vectors,
     ProtGenerics (>= 1.9.1)
 Imports:

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -310,7 +310,11 @@ exportMethods(updateObject,
               writeMSData,
               productMz,
               estimateMzResolution,
-	      combineSpectra
+	      combineSpectra,
+              "isolationWindowLowerMz",
+              "isolationWindowUpperMz",
+              "filterPrecursorMz",
+              "filterIsolationWindow"
               )
 
 ## methods NOT exported

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Changes in version 2.9.5
 ------------------------
 - Add isolationWindowLowerMz and isolationWindowUpperMz methods <2019-04-15 Mon>
 - Add filterPrecursorMz method <2019-04-15 Mon>
+- Add filterIsolationWindow method <2019-05-16 Tue>
 
 Changes in version 2.9.4
 ------------------------

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 Changes in version 2.9.5
 ------------------------
 - Add isolationWindowLowerMz and isolationWindowUpperMz methods <2019-04-15 Mon>
-
+- Add filterPrecursorMz method <2019-04-15 Mon>
 
 Changes in version 2.9.4
 ------------------------

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes in version 2.9.5
+------------------------
+- Add isolationWindowLowerMz and isolationWindowUpperMz methods <2019-04-15 Mon>
+
+
 Changes in version 2.9.4
 ------------------------
 - Remove `NAnnotatedDataframe` <2019-04-10 Wed>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MSnbase 2.9
 
+## Changes in version 2.9.5
+- Add `isolationWindowLowerMz` and `isolationWindowUpperMz` methods <2019-04-15 Mon>
+- Add `filterPrecursorMz` method <2019-04-15 Mon>
+- Add `filterIsolationWindow` method <2019-05-16 Tue>
+
 ## Changes in version 2.9.4
 - Remove `NAnnotatedDataframe` <2019-04-10 Wed>
 

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -155,3 +155,12 @@ setGeneric("estimateMzResolution", function(object, ...)
 
 setGeneric("combineSpectra", function(object, ...)
            standardGeneric("combineSpectra"))
+
+setGeneric("isolationWindowLowerMz", function(object, ...)
+    standardGeneric("isolationWindowLowerMz"))
+setGeneric("isolationWindowUpperMz", function(object, ...)
+    standardGeneric("isolationWindowUpperMz"))
+setGeneric("filterPrecursorMz", function(object, ...)
+    standardGeneric("filterPrecursorMz"))
+setGeneric("filterIsolationWindow", function(object, ...)
+           standardGeneric("filterIsolationWindow"))

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -491,6 +491,9 @@ validSpectrum <- function(object) {
 #' - mergedResultScanNum
 #' - mergedResultStartScanNum
 #' - mergedResultEndScanNum
+#' - isolationWindowTargetMZ
+#' - isolationWindowLowerOffset
+#' - isolationWindowUpperOffset
 #'
 #' @param x `Spectrum` object.
 #'
@@ -519,6 +522,10 @@ validSpectrum <- function(object) {
 #' - spectrumId
 #' - centroided
 #' - ionMobilityDriftTime
+#' - seqNum
+#' - isolationWindowTargetMZ
+#' - isolationWindowLowerOffset
+#' - isolationWindowUpperOffset
 #'
 #' @author Johannes Rainer
 #'
@@ -551,6 +558,9 @@ validSpectrum <- function(object) {
                       spectrumId = paste0("scan=", acquisitionNum(x)),
                       centroided = centroided(x),
                       ionMobilityDriftTime = NA_real_,
+                      isolationWindowTargetMZ = NA_real_,
+                      isolationWindowLowerOffset = NA_real_,
+                      isolationWindowUpperOffset = NA_real_,
                       stringsAsFactors = FALSE
                       )
     if (msLevel(x) > 1) {

--- a/R/methods-MSnExp.R
+++ b/R/methods-MSnExp.R
@@ -416,7 +416,7 @@ setMethod("splitByFile", c("MSnExp", "factor"), function(object, f) {
 #'     enables to extract multiple chromatograms per file, one for each row in
 #'     the matrix. If the number of columns of \code{mz} or \code{rt} are not
 #'     equal to 2, \code{range} is called on each row of the matrix.
-#' 
+#'
 #' @param object For \code{chromatogram}: a \code{\linkS4class{MSnExp}} or
 #'     \code{\linkS4class{OnDiskMSnExp}} object from which the chromatogram
 #'     should be extracted.
@@ -457,7 +457,7 @@ setMethod("splitByFile", c("MSnExp", "factor"), function(object, f) {
 #'     \code{"mzmin"} and \code{"mzmax"} with the values from input argument
 #'     \code{mz} (if used) and \code{"rtmin"} and \code{"rtmax"} if the input
 #'     argument \code{rt} was used.
-#' 
+#'
 #' @author Johannes Rainer
 #'
 #' @seealso \code{\link{Chromatogram}} and \code{\link{Chromatograms}} for the
@@ -497,7 +497,7 @@ setMethod("splitByFile", c("MSnExp", "factor"), function(object, f) {
 #'
 #' ## The mz and/or rt ranges used are provided as featureData of the object
 #' fData(chrs)
-#' 
+#'
 #' ## The mz method can be used to extract the m/z ranges directly
 #' mz(chrs)
 #'

--- a/R/methods-OnDiskMSnExp.R
+++ b/R/methods-OnDiskMSnExp.R
@@ -205,7 +205,7 @@ setMethod("isCentroided", "OnDiskMSnExp",
                   .isCentroided(as(z, "data.frame"), ...))
               ctrd <- unlist(res, use.names = FALSE)
               if (verbose) print(table(ctrd, msLevel(object)))
-              names(ctrd) <- featureNames(object)              
+              names(ctrd) <- featureNames(object)
               ctrd
           })
 
@@ -908,4 +908,19 @@ setMethod("spectrapply", "OnDiskMSnExp", function(object, FUN = NULL,
     names(vals) <- NULL
     vals <- unlist(vals, recursive = FALSE)
     vals[rownames(fData(object))]
+})
+
+setMethod("isolationWindowLowerMz", "OnDiskMSnExp", function(object) {
+    if (all(c("isolationWindowTargetMZ", "isolationWindowLowerOffset") %in%
+            colnames(fData(object))))
+        return(fData(object)$isolationWindowTargetMZ -
+                            fData(object)$isolationWindowLowerOffset)
+    rep(NA_real_, length(object))
+})
+setMethod("isolationWindowUpperMz", "OnDiskMSnExp", function(object) {
+    if (all(c("isolationWindowTargetMZ", "isolationWindowUpperOffset") %in%
+            colnames(fData(object))))
+        return(fData(object)$isolationWindowTargetMZ +
+                            fData(object)$isolationWindowUpperOffset)
+    rep(NA_real_, length(object))
 })

--- a/R/methods-filters.R
+++ b/R/methods-filters.R
@@ -190,4 +190,16 @@ setMethod("filterPrecursorScan", "MSnExp",
             object
         })
 
-## setMethod("filterPrecursorMz", "MSnExp", function(object, ...))
+setMethod("filterPrecursorMz", "MSnExp", function(object, mz, ppm = 10) {
+    if (missing(mz))
+        return(object)
+    if (length(mz) > 1)
+        stop("'mz' is expected to be a single m/z value")
+    mz_ppm <- ppm * mz / 1e6
+    idx <- which(precursorMz(object) >= (mz - mz_ppm) &
+                 precursorMz(object) <= (mz + mz_ppm))
+    msg <- paste0("Filter: select by precursor m/z: ", mz, ".")
+    object <- object[idx]
+    object <- logging(object, msg)
+    object
+})

--- a/R/methods-filters.R
+++ b/R/methods-filters.R
@@ -190,16 +190,62 @@ setMethod("filterPrecursorScan", "MSnExp",
             object
         })
 
+#' @description
+#'
+#' Filter `object` reducing to MS data (spectra) for which the precursor m/z
+#' matches the provided m/z accepting a small difference which can be defined
+#' with the `ppm` parameter.
+#'
+#' @param object `MSnExp` object.
+#'
+#' @param mz `numeric(1)` with the m/z value to filter the object.
+#'
+#' @param ppm `numeric(1)` defining the accepted difference between the
+#'     provided m/z and the spectrum's m/z in parts per million.
+#'
+#' @md
+#'
+#' @noRd
+#'
+#' @author Johannes Rainer
 setMethod("filterPrecursorMz", "MSnExp", function(object, mz, ppm = 10) {
     if (missing(mz))
         return(object)
     if (length(mz) > 1)
-        stop("'mz' is expected to be a single m/z value")
+        stop("'mz' is expected to be a single m/z value", call. = FALSE)
     mz_ppm <- ppm * mz / 1e6
-    idx <- which(precursorMz(object) >= (mz - mz_ppm) &
+    keep <- which(precursorMz(object) >= (mz - mz_ppm) &
                  precursorMz(object) <= (mz + mz_ppm))
+    object <- object[keep]
     msg <- paste0("Filter: select by precursor m/z: ", mz, ".")
-    object <- object[idx]
+    object <- logging(object, msg)
+    object
+})
+
+#' @description
+#'
+#' Filter the object based on the isolation window. The resulting object will
+#' contain all spectra with isolation windows containing the specified m/z.
+#'
+#' @param object `MSnExp` object.
+#'
+#' @param mz `numeric(1)` with the m/z tha should be within the isolation
+#'     window's m/z range.
+#'
+#' @md
+#'
+#' @noRd
+#'
+#' @author Johannes Rainer
+setMethod("filterIsolationWindow", "MSnExp", function(object, mz, ...){
+    if (missing(mz))
+        return(object)
+    if (length(mz) > 1)
+        stop("'mz' is expected to be a single m/z value", call. = FALSE)
+    keep <- which(isolationWindowLowerMz(object) <= mz &
+                  isolationWindowUpperMz(object) >= mz)
+    object <- object[keep]
+    msg <- paste0("Filter isolation windows containing : ", mz, ".")
     object <- logging(object, msg)
     object
 })

--- a/R/methods-filters.R
+++ b/R/methods-filters.R
@@ -189,3 +189,5 @@ setMethod("filterPrecursorScan", "MSnExp",
             )
             object
         })
+
+## setMethod("filterPrecursorMz", "MSnExp", function(object, ...))

--- a/R/methods-pSet.R
+++ b/R/methods-pSet.R
@@ -570,6 +570,11 @@ setReplaceMethod("phenoData", "pSet", function(object, value) {
         object
 })
 
+setMethod("isolationWindowLowerMz", "pSet", function(object)
+    stop("isolationWindowLowerMz not available for ", class(object)))
+setMethod("isolationWindowUpperMz", "pSet", function(object)
+    stop("isolationWindowUpperMz not available for ", class(object)))
+
 ################################
 ## TODO: setReplaceMethods for
 ##  phenoData

--- a/man/MSnExp-class.Rd
+++ b/man/MSnExp-class.Rd
@@ -65,6 +65,8 @@
 \alias{filterPrecursorScan,OnDiskMSnExp-method}
 \alias{filterPrecursorMz}
 \alias{filterPrecursorMz,MSnExp-method}
+\alias{filterIsolationWindow}
+\alias{filterIsolationWindow,MSnExp-method}
 
 \alias{isCentroided,MSnExp-method}
 
@@ -332,6 +334,11 @@
 	the one defined with parameter \code{mz}. Parameter \code{ppm}
 	allows to define an accepted difference between the provided m/z
 	and the spectrum's m/z.
+    }
+
+    \item{filterIsolationWindow}{\code{signature(object = "MSnExp",
+	mz)}: retain spectra with isolation windows that contain
+	(which m/z range contain) the specified m/z.
     }
   }
 }

--- a/man/MSnExp-class.Rd
+++ b/man/MSnExp-class.Rd
@@ -63,6 +63,8 @@
 \alias{filterPrecursorScan}
 \alias{filterPrecursorScan,MSnExp-method}
 \alias{filterPrecursorScan,OnDiskMSnExp-method}
+\alias{filterPrecursorMz}
+\alias{filterPrecursorMz,MSnExp-method}
 
 \alias{isCentroided,MSnExp-method}
 
@@ -323,6 +325,13 @@
         "factor")}: split a \code{MSnExp} object by file into a
       \code{list} of \code{MSnExp} objects given the grouping in
       \code{factor} \code{f}.
+    }
+
+    \item{filterPrecursorMz}{\code{signature(object = "MSnExp", mz, ppm
+	= 10)}: retain spectra with a precursor m/z equal or similar to
+	the one defined with parameter \code{mz}. Parameter \code{ppm}
+	allows to define an accepted difference between the provided m/z
+	and the spectrum's m/z.
     }
   }
 }

--- a/man/OnDiskMSnExp-class.Rd
+++ b/man/OnDiskMSnExp-class.Rd
@@ -46,6 +46,8 @@
 \alias{precScanNum,OnDiskMSnExp-method}
 \alias{precursorIntensity,OnDiskMSnExp-method}
 \alias{collisionEnergy,OnDiskMSnExp-method}
+\alias{isolationWindowLowerMz,OnDiskMSnExp-method}
+\alias{isolationWindowUpperMz,OnDiskMSnExp-method}
 
 \alias{compareSpectra,OnDiskMSnExp,missing-method}
 \alias{estimateNoise,OnDiskMSnExp-method}
@@ -250,16 +252,6 @@ Class \code{"\linkS4class{Versioned}"}, by class "pSet", distance 5.
 
     }
 
-    \item{smoothed,smoothed<-}{
-      \code{smoothed(signature(object="OnDiskMSnExp", msLevel. =
-      "numeric"))}: whether individual spectra are smoothed or
-      unsmoothed. The relevant information is extracted from the
-      object's \code{featureData} slot. Returns a logical vector with
-      names corresponding to the spectrum names.  Use
-      \code{smoothed(object) <- value} to update the information, with
-      value being a logical vector of length equal to the number of
-      spectra in the experiment.  }
-
     \item{fromFile}{
       \code{fromFile(signature(object = "OnDiskMSnExp"))}: get the
       index of the file (in \code{fileNames(object)}) from which the
@@ -299,6 +291,24 @@ Class \code{"\linkS4class{Versioned}"}, by class "pSet", distance 5.
 
       Returns a numeric vector with names corresponding to the spectrum
       names.
+    }
+
+    \item{isolationWindowLowerMz}{
+      \code{isolationWindowLowerMz(object = "OnDiskMSnExp")}: return the
+      lower m/z boundary for the isolation window.
+
+      Returns a numeric vector of length equal to the number of spectra
+      with the lower m/z value of the isolation window or \code{NA} if
+      not specified in the original file.
+    }
+
+    \item{isolationWindowUpperMz}{
+      \code{isolationWindowUpperMz(object = "OnDiskMSnExp")}: return the
+      upper m/z boundary for the isolation window.
+
+      Returns a numeric vector of length equal to the number of spectra
+      with the upper m/z value of the isolation window or \code{NA} if
+      not specified in the original file.
     }
 
     \item{length}{
@@ -372,6 +382,16 @@ Class \code{"\linkS4class{Versioned}"}, by class "pSet", distance 5.
       Returns a numeric vector of indices with names corresponding to the
       spectrum names.
     }
+
+    \item{smoothed,smoothed<-}{
+      \code{smoothed(signature(object="OnDiskMSnExp", msLevel. =
+      "numeric"))}: whether individual spectra are smoothed or
+      unsmoothed. The relevant information is extracted from the
+      object's \code{featureData} slot. Returns a logical vector with
+      names corresponding to the spectrum names.  Use
+      \code{smoothed(object) <- value} to update the information, with
+      value being a logical vector of length equal to the number of
+      spectra in the experiment.  }
 
     \item{spectra}{
       \code{spectra(signature(object="OnDiskMSnExp"), BPPARAM=bpparam())}:

--- a/man/pSet-class.Rd
+++ b/man/pSet-class.Rd
@@ -83,6 +83,10 @@
 \alias{instrumentCustomisations,pSet-method}
 \alias{detectorType,pSet-method}
 \alias{description,pSet-method}
+\alias{isolationWindowLowerMz}
+\alias{isolationWindowUpperMz}
+\alias{isolationWindowLowerMz,pSet-method}
+\alias{isolationWindowUpperMz,pSet-method}
 
 \alias{spectrapply}
 \alias{spectrapply,pSet-method}
@@ -279,6 +283,21 @@
 
       Returns a list with the result for each of spectrum.
     }
+
+    \item{isolationWindowLowerMz}{
+      \code{isolationWindowLowerMz(object = "pSet")}: return the
+      lower m/z boundary for the isolation window. Note that this method
+      is at present only available for \code{\linkS4class{OnDiskMSnExp}}
+      objects.
+    }
+
+    \item{isolationWindowUpperMz}{
+      \code{isolationWindowUpperMz(object = "pSet")}: return the
+      upper m/z boundary for the isolation window. Note that this method
+      is at present only available for \code{\linkS4class{OnDiskMSnExp}}
+      objects.
+    }
+
   }
 
   Additional accessors for the experimental metadata

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -312,7 +312,7 @@ test_that("isolation window", {
 test_that("spectrapply,MSnExp", {
     library(msdata)
     inMem <- microtofq_in_mem_ms1
-    
+
     sps <- spectra(inMem)
     sps_2 <- spectrapply(inMem)
     expect_identical(sps, sps_2)
@@ -374,7 +374,7 @@ test_that("phenoData<- on MSnExp works", {
     ## Assign AnnotatedDataFrame
     phenoData(im) <- pd_2
     expect_true(is(im@phenoData, "AnnotatedDataFrame"))
-    expect_equal(phenoData(im), pd_2)    
+    expect_equal(phenoData(im), pd_2)
 })
 
 test_that("injection time", {
@@ -390,7 +390,7 @@ test_that("chromatogram,MSnExp works", {
     ## Reduce here the tests. Most of the tests are performed in
     ## chromatogram,OnDiskMSnExp and both methods use the same low level
     ## function.
-    
+
     ## Multiple mz ranges.
     mzr <- matrix(c(100, 120, 200, 220, 300, 320), nrow = 3, byrow = TRUE)
     rtr <- matrix(c(50, 300), nrow = 1)
@@ -423,7 +423,7 @@ test_that("chromatogram,MSnExp works", {
     expect_equal(fData(res)$mzmin, c(100, 200, 300))
     expect_equal(fData(res)$mzmax, c(120, 220, 320))
     expect_equal(fData(res)$polarity, c(1, 1, 1))
-    
+
     ## Now with ranges for which we don't have values in one or the other.
     rtr <- matrix(c(280, 300, 20, 40), nrow = 2,
                   byrow = TRUE)  ## Only present in first, or 2nd file
@@ -522,7 +522,7 @@ test_that("estimateMzScattering works", {
 test_that("combineSpectraMovingWindow works", {
     ## Check errors
     expect_error(combineSpectraMovingWindow("3"))
-    
+
     od <- filterFile(sciex, 1)
     ## Focus on the one with most peaks
     idx <- which.max(peaksCount(od))
@@ -534,7 +534,7 @@ test_that("combineSpectraMovingWindow works", {
     ## Should be different from raw ones
     expect_true(is.character(all.equal(mz(spctr), mz(od[[4]]))))
     expect_true(is.character(all.equal(intensity(spctr), intensity(od[[4]]))))
-    
+
     ## Use pre-calculated mzd:
     mzd <- estimateMzScattering(od)
     ## If mzd is estimated on mz and combination on sqrt(mz) it will fail.
@@ -546,7 +546,7 @@ test_that("combineSpectraMovingWindow works", {
     spctr_comb <- od_comb[[4]]
     expect_equal(mz(spctr_comb), mz(spctr))
     expect_equal(intensity(spctr_comb), intensity(spctr))
-    
+
     ## Estimate on the sqrt(mz)
     mzd <- estimateMzScattering(od, timeDomain = TRUE)
     od_comb <- combineSpectraMovingWindow(od, mzd = mzd[[4]], timeDomain = TRUE)
@@ -557,7 +557,7 @@ test_that("combineSpectraMovingWindow works", {
     spctr_raw <- od[[4]]
     expect_true(is.character(all.equal(mz(spctr), mz(spctr_raw))))
     expect_true(is.character(all.equal(intensity(spctr), intensity(spctr_raw))))
-    
+
     ## Shouldn't make a difference if we're using timeDomain = TRUE or FALSE.
     od_comb <- combineSpectraMovingWindow(od)
     spctr_comb <- od_comb[[4]]
@@ -594,4 +594,9 @@ test_that("as,MSnExp,Spectra works", {
     expect_equal(msLevel(res), msLevel(sciex))
     expect_equal(intensity(res), intensity(sciex))
     expect_true(ncol(mcols(res)) > 0)
+})
+
+test_that("isolationWindowLowerMz, isolationWindowUpperMz work", {
+    expect_error(isolationWindowLowerMz(tmt_im_ms2_sub), "not available")
+    expect_error(isolationWindowUpperMz(tmt_im_ms2_sub), "not available")
 })

--- a/tests/testthat/test_MSnExpFilters.R
+++ b/tests/testthat/test_MSnExpFilters.R
@@ -179,4 +179,28 @@ test_that("filterPrecursorMz works", {
     expect_true(length(res) == 1)
     res <- filterPrecursorMz(tmt_od_sub, mz = 417.75, ppm = 100)
     expect_true(length(res) == 2)
+
+    res <- filterPrecursorMz(tmt_od_sub)
+    expect_equal(length(res), length(tmt_od_sub))
+
+    expect_error(filterPrecursorMz(sciex, mz = 233), "MS1 spectra")
+
+    expect_error(filterPrecursorMz(tmt_od_sub, mz = c(1, 2)), "single m/z")
+})
+
+test_that("filterIsolationWindow works", {
+    res <- filterIsolationWindow(tmt_od_sub)
+    expect_equal(length(res), length(tmt_od_sub))
+
+    res <- filterIsolationWindow(tmt_od_sub, mz = 411)
+    expect_equal(length(res), 2)
+    expect_true(all(isolationWindowLowerMz(res) < 411))
+    expect_true(all(isolationWindowUpperMz(res) > 411))
+
+    expect_error(filterIsolationWindow(tmt_od_sub, mz = c(1, 2)), "single m/z")
+
+    expect_error(filterIsolationWindow(tmt_im_ms2_sub, mz = 411), "not available")
+
+    res <- filterIsolationWindow(sciex, mz = 411)
+    expect_true(length(res) == 0)
 })

--- a/tests/testthat/test_MSnExpFilters.R
+++ b/tests/testthat/test_MSnExpFilters.R
@@ -167,3 +167,16 @@ test_that("filterPolarity", {
     expect_identical(length(filterPolarity(rw, 1)), sum(pol2 == 1))
     expect_identical(length(filterPolarity(rw, -1)), sum(pol2 == -1))
 })
+
+test_that("filterPrecursorMz works", {
+    res <- filterPrecursorMz(tmt_im_ms2_sub, mz = 417.75, ppm = 20)
+    expect_true(length(res) == 1)
+
+    res <- filterPrecursorMz(tmt_im_ms2_sub, mz = 417.75, ppm = 100)
+    expect_true(length(res) == 2)
+
+    res <- filterPrecursorMz(tmt_od_sub, mz = 417.75, ppm = 20)
+    expect_true(length(res) == 1)
+    res <- filterPrecursorMz(tmt_od_sub, mz = 417.75, ppm = 100)
+    expect_true(length(res) == 2)
+})

--- a/tests/testthat/test_OnDiskMSnExp.R
+++ b/tests/testthat/test_OnDiskMSnExp.R
@@ -296,7 +296,7 @@ test_that("splitByFile,OnDiskMSnExp", {
     expect_error(splitByFile(od, f = factor(1:3)))
     spl <- splitByFile(od, f = factor(c("b", "a")))
     expect_equal(pData(spl[[1]]), pData(filterFile(od, 2)))
-    expect_equal(pData(spl[[2]]), pData(filterFile(od, 1)))    
+    expect_equal(pData(spl[[2]]), pData(filterFile(od, 1)))
 })
 
 test_that("chromatogram,OnDiskMSnExp works", {
@@ -307,7 +307,7 @@ test_that("chromatogram,OnDiskMSnExp works", {
     file.copy(mzf[1], paste0(tmpd, "a.mzML"))
     file.copy(mzf[2], paste0(tmpd, "b.mzML"))
     mzf <- c(mzf, paste0(tmpd, c("a.mzML", "b.mzML")))
-    
+
     onDisk <- readMSData(files = mzf, msLevel. = 1, centroided. = TRUE,
                          mode = "onDisk")
 
@@ -400,9 +400,9 @@ test_that("low memory spectrapply function works", {
     fData$fileIdx <- 1L
     fData$smoothed <- FALSE
     fData$centroided <- TRUE
-    
+
     fastLoad <- FALSE
-    
+
     expect_equal(
         MSnbase:::.applyFun2SpectraOfFileMulti(fData, filenames = fl,
                                                fastLoad = fastLoad),
@@ -427,3 +427,15 @@ test_that("low memory spectrapply function works", {
                                                     APPLYFUN = mz))
 })
 
+test_that("isolationWindowLowerMz,isolationWindowUpperMz,OnDiskMSnExp works", {
+    mz_low <- isolationWindowLowerMz(tmt_od_ms2_sub)
+    mz_high <- isolationWindowUpperMz(tmt_od_ms2_sub)
+    expect_true(all(mz_low < mz_high))
+    expect_true(all(precursorMz(tmt_od_ms2_sub) >= mz_low))
+    expect_true(all(precursorMz(tmt_od_ms2_sub) <= mz_high))
+
+    mz_low <- isolationWindowLowerMz(sciex)
+    mz_high <- isolationWindowUpperMz(sciex)
+    expect_true(all(is.na(mz_low)))
+    expect_true(all(is.na(mz_high)))
+})

--- a/tests/testthat/test_Spectrum.R
+++ b/tests/testthat/test_Spectrum.R
@@ -119,7 +119,7 @@ test_that("Spectrum quantification", {
               mz = mz,
               centroided = FALSE)
     expect_true(validObject(sp))
-    expect_equal(MSnbase:::getCurveWidth(sp, iTRAQ4[1]),
+    expect_equal(getCurveWidth(sp, iTRAQ4[1]),
                  list(lwr = 1, upr = 5))
     expect_equal(as.numeric(quantify(sp, "sum", iTRAQ4[1])$peakQuant), 6)
     expect_equal(as.numeric(quantify(sp, "max", iTRAQ4[1])$peakQuant), 3)
@@ -187,27 +187,27 @@ test_that(".fix_breaks works as breaks_Spectra", {
     brks <- seq(floor(min(c(mz(s1), mz(s1)))),
                 ceiling(max(c(mz(s1), mz(s1)))), by = 1)
     expect_equal(brks, 1:4)
-    expect_equal(MSnbase:::.fix_breaks(brks, c(1, 4)), 1:5)
+    expect_equal(.fix_breaks(brks, c(1, 4)), 1:5)
     brks <- seq(floor(min(c(mz(s1), mz(s2)))),
                 ceiling(max(c(mz(s1), mz(s2)))), by = 1)
     expect_equal(brks, 1:5)
     ## issue 190
-    expect_equal(MSnbase:::.fix_breaks(brks, c(1, 5)), 1:6)
+    expect_equal(.fix_breaks(brks, c(1, 5)), 1:6)
     brks <- seq(floor(min(c(mz(s1), mz(s2)))),
                 ceiling(max(c(mz(s1), mz(s2)))), by = 2)
     expect_equal(brks, c(1, 3, 5))
-    expect_equal(MSnbase:::.fix_breaks(brks, c(1, 6)), c(1, 3, 5, 7))
+    expect_equal(.fix_breaks(brks, c(1, 6)), c(1, 3, 5, 7))
 
     s3 <- new("Spectrum2", mz = 1:4, intensity = 1:4)
     s4 <- new("Spectrum2", mz = 11:15, intensity = 1:5)
     brks <- seq(floor(min(c(mz(s3), mz(s4)))),
                 ceiling(max(c(mz(s3), mz(s4)))), by = 1)
     expect_equal(brks, 1:15)
-    expect_equal(MSnbase:::.fix_breaks(brks, c(1, 15)), 1:16)
+    expect_equal(.fix_breaks(brks, c(1, 15)), 1:16)
     brks <- seq(floor(min(c(mz(s3), mz(s4)))),
                 ceiling(max(c(mz(s3), mz(s4)))), by = 2)
     expect_equal(brks, seq(1, 15, 2))
-    expect_equal(MSnbase:::.fix_breaks(brks, c(1, 15)), seq(1, 17, by=2))
+    expect_equal(.fix_breaks(brks, c(1, 15)), seq(1, 17, by=2))
 })
 
 test_that("bin_Spectrum", {
@@ -218,13 +218,13 @@ test_that("bin_Spectrum", {
     r3 <- new("Spectrum2", mz = c(2, 4, 6), intensity = c(1.5, 3.5, 5), tic = 10)
     r31 <- new("Spectrum2", mz = c(2, 4, 6), intensity = c(1.5, 3.5, 5), tic = 10)
     r4 <- new("Spectrum2", mz = c(1, 3, 5), intensity = c(1, 5, 9), tic = 15)
-    expect_equal(MSnbase:::bin_Spectrum(s1, binSize = 1), r1)
-    expect_equal(MSnbase:::bin_Spectrum(s1, binSize = 2), r2)
-    expect_equal(MSnbase:::bin_Spectrum(s1, binSize = 2, fun = mean), r3)
-    expect_equal(MSnbase:::bin_Spectrum(s1, breaks = seq(0, 7, by = 2)), r4)
-    expect_equal(MSnbase:::bin_Spectrum(s2, binSize = 1), r1)
-    expect_equal(MSnbase:::bin_Spectrum(s2, binSize = 2, fun = mean), r31)
-    expect_equal(MSnbase:::bin_Spectrum(s2, breaks = seq(0, 7, by = 2)), r4)
+    expect_equal(bin_Spectrum(s1, binSize = 1), r1)
+    expect_equal(bin_Spectrum(s1, binSize = 2), r2)
+    expect_equal(bin_Spectrum(s1, binSize = 2, fun = mean), r3)
+    expect_equal(bin_Spectrum(s1, breaks = seq(0, 7, by = 2)), r4)
+    expect_equal(bin_Spectrum(s2, binSize = 1), r1)
+    expect_equal(bin_Spectrum(s2, binSize = 2, fun = mean), r31)
+    expect_equal(bin_Spectrum(s2, breaks = seq(0, 7, by = 2)), r4)
 })
 
 test_that("bin_Spectrum - bug fix #ecaaa324505b17ee8c4855806f7e37f14f1b27b8", {
@@ -246,8 +246,8 @@ test_that("bin_Spectra", {
     r1 <- new("Spectrum2", mz = 1:5 + 0.5, intensity = c(1:4, 0))
     r2 <- new("Spectrum2", mz = 1:5 + 0.5, intensity = 1:5)
     r3 <- new("Spectrum2", mz = 1:4 + 0.5, intensity = 1:4)
-    expect_equal(MSnbase:::bin_Spectra(s1, s2), list(r1, r2))
-    expect_equal(MSnbase:::bin_Spectra(s1, s1), list(r3, r3))
+    expect_equal(bin_Spectra(s1, s2), list(r1, r2))
+    expect_equal(bin_Spectra(s1, s1), list(r3, r3))
 })
 
 test_that("removePeaks profile vs centroided", {
@@ -303,7 +303,7 @@ test_that(".spectrum_header works", {
     sp_1 <- tmt_erwinia_on_disk[[1]]
     sp_2 <- tmt_erwinia_on_disk[[2]]
 
-    hdr_1 <- MSnbase:::.spectrum_header(sp_1)
+    hdr_1 <- .spectrum_header(sp_1)
     hdr_1$seqNum <- 1L
     expect_true(all(colnames(hdr) %in% colnames(hdr_1)))
     cns <- colnames(hdr)
@@ -312,7 +312,7 @@ test_that(".spectrum_header works", {
     for (cn in cns)
         expect_equal(hdr[1, cn], hdr_1[1, cn])
 
-    hdr_2 <- MSnbase:::.spectrum_header(sp_2)
+    hdr_2 <- .spectrum_header(sp_2)
     hdr_2$seqNum <- 1L
     expect_true(all(colnames(hdr) %in% colnames(hdr_2)))
     for (cn in cns)
@@ -481,16 +481,16 @@ test_that(".group_mz_values works", {
     all_mz <- sort(c(mzs + rnorm(length(mzs), sd = 0.001),
                      mzs + rnorm(length(mzs), sd = 0.005),
                      mzs + rnorm(length(mzs), sd = 0.002)))
-    res <- MSnbase:::.group_mz_values(all_mz)
+    res <- .group_mz_values(all_mz)
     expect_true(length(res) == length(all_mz))
     ## Expect groups of 3 each.
     expect_true(all(table(res) == 3))
 
     ## Remove one from the 2nd group.
-    res <- MSnbase:::.group_mz_values(all_mz[-5])
+    res <- .group_mz_values(all_mz[-5])
     expect_true(sum(res == 2) == 2)
 
-    res <- MSnbase:::.group_mz_values(all_mz, ppm = 20)
+    res <- .group_mz_values(all_mz, ppm = 20)
     expect_true(all(table(res) == 3))
 })
 
@@ -571,7 +571,7 @@ test_that("meanMzInts works", {
     expect_equal(mz(res), mz(res_2))
     expect_equal(intensity(res), intensity(res_2))
     ## with (wrongly) pre-calculated mzd
-    mzd <- MSnbase:::.estimate_mz_scattering(sort(unlist(lapply(lst, mz))))
+    mzd <- .estimate_mz_scattering(sort(unlist(lapply(lst, mz))))
     expect_warning(meanMzInts(lst, timeDomain = TRUE, mzd = mzd))
     res_3 <- meanMzInts(lst, timeDomain = FALSE, mzd = mzd, main = 2)
 

--- a/tests/testthat/test_writeMSData.R
+++ b/tests/testthat/test_writeMSData.R
@@ -59,7 +59,8 @@ test_that("writeMSData works", {
                                      c(not_equal, "retentionTime",
                                        "precursorScanNum", "acquisitionNum",
                                        "injectionTime", "spectrumId",
-                                       "filterString"))]
+                                       "filterString",
+                                       "isolationWindowTargetMZ"))]
     expect_equal(fd_out[, check_cols], fd_in[, check_cols])
     ## Again force check:
     expect_equal(unname(precursorCharge(odf_out)),
@@ -80,7 +81,7 @@ test_that("writeMSData works", {
     expect_equal(res$status, 0)
     doc <- XML::xmlInternalTreeParse(out_file[2])
     res <- XML::xmlSchemaValidate(mzML_xsd_idx, doc)
-    expect_equal(res$status, 0)    
+    expect_equal(res$status, 0)
     odf_in <- readMSData(out_file, mode = "onDisk")
     expect_equal(unname(rtime(odf_in)), unname(rtime(microtofq_in_mem_ms1)))
     expect_equal(spectra(odf_in), spectra(microtofq_in_mem_ms1))
@@ -93,14 +94,13 @@ test_that("writeMSData works", {
     expect_equal(unname(rtime(odf)), unname(rtime(odf_in)))
     expect_equal(unname(mz(odf)), unname(mz(odf_in)))
     expect_equal(unname(intensity(odf)), unname(intensity(odf_in)))
-
 })
 
 test_that(".pattern_to_cv works", {
     ## Not found.
     expect_equal(.pattern_to_cv("unknown"), NA_character_)
     expect_equal(.pattern_to_cv("peak picking"), "MS:1000035")
-    expect_equal(.pattern_to_cv("centroid"), "MS:1000035")    
+    expect_equal(.pattern_to_cv("centroid"), "MS:1000035")
     expect_equal(.pattern_to_cv("Alignment/retention time adjustment"),
                  "MS:1000745")
 })
@@ -187,7 +187,7 @@ test_that("writeMSData,OnDiskMSnExp works", {
                       as.numeric(factor(fData(in_data)$precursorScanNum))
     expect_equal(fData(out_data)[, check_cols], fData(in_data)[, check_cols])
     expect_equal(fData(out_data)$filterString, fData(in_data)$filterString)
-    
+
     ## With copy = TRUE
     out_file <- paste0(tempfile(), ".mzML")
     out_data <- tmt_erwinia_on_disk
@@ -225,7 +225,7 @@ test_that("writeMSData,MSnExp works", {
     expect_equal(unname(precursorIntensity(odf_in)),
                  unname(precursorIntensity(extdata_mzXML_in_mem_ms2)))
 
-    in_file <- system.file(package = "msdata", 
+    in_file <- system.file(package = "msdata",
                            "proteomics/MS3TMT10_01022016_32917-33481.mzML.gz")
     data_out <- readMSData(in_file, msLevel = 3, mode = "inMem")
     out_file <- paste0(tempfile(), ".mzML")


### PR DESCRIPTION
Add methods
- `filterPrecursorMz`
- `isolationWindowLowerOffset`
- `isolationWindowUpperOffset`
- `filterIsolationWindow`

Note that the latter 3 don't work on `MSnExp` objects because the required header information is not represented by a slot in the `Spectrum2` object.

Also, the PR fixes issue #459 (unit test errors because with the recent `mzR` update `isolationWindowLowerOffset`, `isolationWindowUpperOffset` and `isolationWindowTargetMZ` header columns are returned too).