### PR TITLE
Add parameter msLevel to pickPeaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,7 @@ Depends:
     methods,
     BiocGenerics (>= 0.7.1),
     Biobase (>= 2.15.2),
-    mzR (>= 2.17.3),
+    mzR (>= 2.17.4),
     S4Vectors,
     ProtGenerics (>= 1.17.2)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.11.3
+Version: 2.11.4
 Description: MSnbase provides infrastructure for manipulation,
 	     processing and visualisation of mass spectrometry and
 	     proteomics data, ranging from raw to quantitative and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-<<<<<<< HEAD
-Version: 2.11.4
-=======
 Version: 2.11.6
->>>>>>> master
 Description: MSnbase provides infrastructure for manipulation,
 	     processing and visualisation of mass spectrometry and
 	     proteomics data, ranging from raw to quantitative and

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## MSnbase 2.11.4
 
+- Update to match changes in mzR version 2.17.4 <2019-09-04 Wed>.
 - Add parameter `msLevel` to `pickPeaks` to allow peak picking in specific MS
   levels. See [#478](https://github.com/lgatto/MSnbase/issues/478)  <2019-09-04
   Wed>.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,10 @@
 
 ## MSnbase 2.11.6
 
-- Nothing yet.
+- Update to match changes in mzR version 2.17.4 <2019-09-04 Wed>.
+- Add parameter `msLevel` to `pickPeaks` to allow peak picking in specific MS
+  levels. See [#478](https://github.com/lgatto/MSnbase/issues/478)  <2019-09-04
+  Wed>.
 
 ## MSnbase 2.11.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # MSnbase 2.11
 
+## MSnbase 2.11.4
+
+- Add parameter `msLevel` to `pickPeaks` to allow peak picking in specific MS
+  levels. See [#478](https://github.com/lgatto/MSnbase/issues/478)  <2019-09-04
+  Wed>.
+
 ## MSnbase 2.11.3
 
 - Make combineFeatures a method <2019-05-31 Fri>

--- a/R/functions-MSnExp.R
+++ b/R/functions-MSnExp.R
@@ -231,7 +231,7 @@ compare_MSnExp <- function(object, fun, ...) {
 }
 
 pickPeaks_MSnExp <- function(object, halfWindowSize, method, SNR,
-                             ..., verbose = isMSnbaseVerbose()) {
+                             ..., msLevel., verbose = isMSnbaseVerbose()) {
   ## copied from clean_MSnExp
   e <- new.env()
 
@@ -248,7 +248,8 @@ pickPeaks_MSnExp <- function(object, halfWindowSize, method, SNR,
            }
            sp <- get(x, envir = assayData(object))
            xx <- pickPeaks(sp, halfWindowSize = halfWindowSize,
-                           method = method, SNR = SNR, ...)
+                           method = method, SNR = SNR, msLevel. = msLevel.,
+                           ...)
            assign(x, xx, envir = e)
            invisible(TRUE)
          })
@@ -270,7 +271,7 @@ pickPeaks_MSnExp <- function(object, halfWindowSize, method, SNR,
                                       hd = hd),
                                  object@.cache$level)
   }
-    lockEnvironment(e, bindings = TRUE)    
+    lockEnvironment(e, bindings = TRUE)
     object@assayData <- e
     if (validObject(object))
     return(object)
@@ -315,7 +316,7 @@ smooth_MSnExp <- function(object, method, halfWindowSize, ...,
                                       hd = hd),
                                  object@.cache$level)
   }
-    lockEnvironment(e, bindings = TRUE)    
+    lockEnvironment(e, bindings = TRUE)
     object@assayData <- e
     if (validObject(object))
     return(object)
@@ -377,7 +378,7 @@ removeReporters_MSnExp <- function(object, reporters = NULL,
 #'
 #' For `timeDomain = TRUE` the function does **not** return the estimated
 #' scattering of m/z values, but the scattering of `sqrt(mz)` values.
-#' 
+#'
 #' @param x `MSnExp` or `OnDiskMSnExp` object.
 #'
 #' @param halfWindowSize `integer(1)` defining the half window size for the
@@ -387,7 +388,7 @@ removeReporters_MSnExp <- function(object, reporters = NULL,
 #'     on `mz` (`timeDomain = FALSE`) or `sqrt(mz)` (`timeDomain = TRUE`)
 #'     values. See [combineSpectraMovingWindow()] for details on this
 #'     parameter.
-#' 
+#'
 #' @author Johannes Rainer
 #'
 #' @md
@@ -396,7 +397,7 @@ removeReporters_MSnExp <- function(object, reporters = NULL,
 #'     profile-mode spectrum's m/z resolution from it's data.
 #'
 #' @examples
-#' 
+#'
 #' library(MSnbase)
 #' library(msdata)
 #' ## Load a profile-mode LC-MS data file
@@ -440,7 +441,7 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #'
 #' Note that the function returns always a `MSnExp` object, even if `x` was an
 #' `OnDiskMSnExp` object.
-#' 
+#'
 #' @details
 #'
 #' The method assumes same ions being measured in consecutive scans (i.e. LCMS
@@ -448,7 +449,7 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #' signal to noise ratio.
 #'
 #' Intensities (and m/z values) for signals with the same m/z value in
-#' consecutive scans are aggregated using the `intensityFun`. 
+#' consecutive scans are aggregated using the `intensityFun`.
 #' m/z values of intensities from consecutive scans will never be exactly
 #' identical, even if they represent signal from the same ion. The function
 #' determines thus internally a similarity threshold based on differences
@@ -456,7 +457,7 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #' considered to derive from the same ion. For robustness reasons, this
 #' threshold is estimated on the 100 spectra with the largest number of
 #' m/z - intensity pairs (i.e. mass peaks).
-#' 
+#'
 #' See [meanMzInts()] for details.
 #'
 #' Parameter `timeDomain`: by default, m/z-intensity pairs from consecutive
@@ -469,7 +470,7 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #' scattering being different in the lower and upper m/z range. Determining
 #' m/z values to be combined on the `sqrt(mz)` reduces this dependency. For
 #' non-QTOF MS data `timeDomain = FALSE` might be used instead.
-#' 
+#'
 #' @note
 #'
 #' The function has to read all data into memory for the spectra combining
@@ -477,14 +478,14 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #' preventing its usage on large experimental data. In these cases it is
 #' suggested to perform the combination on a per-file basis and save the
 #' results using the [writeMSData()] function afterwards.
-#' 
+#'
 #' @param x `MSnExp` or `OnDiskMSnExp` object.
 #'
 #' @param halfWindowSize `integer(1)` with the half window size for the moving
 #'     window.
-#' 
+#'
 #' @param BPPARAM parallel processing settings.
-#' 
+#'
 #' @inheritParams meanMzInts
 #'
 #' @return `MSnExp` with the same number of spectra than `x`.
@@ -498,7 +499,7 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #'
 #' [estimateMzScattering()] for a function to estimate m/z value scattering in
 #' consecutive spectra.
-#' 
+#'
 #' @author Johannes Rainer, Sigurdur Smarason
 #'
 #' @examples
@@ -525,7 +526,7 @@ estimateMzScattering <- function(x, halfWindowSize = 1L, timeDomain = FALSE) {
 #'
 #' peaksCount(od)
 #' peaksCount(od_comb)
-#' 
+#'
 #' ## Comparing the chromatographic signal for proline (m/z ~ 116.0706)
 #' ## before and after spectra data combination.
 #' mzr <- c(116.065, 116.075)

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -565,6 +565,8 @@ validSpectrum <- function(object) {
                       isolationWindowTargetMZ = NA_real_,
                       isolationWindowLowerOffset = NA_real_,
                       isolationWindowUpperOffset = NA_real_,
+                      scanWindowLowerLimit = NA_real_,
+                      scanWindowUpperLimit = NA_real_,
                       stringsAsFactors = FALSE
                       )
     if (msLevel(x) > 1) {

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -375,7 +375,11 @@ pickPeaks_Spectrum <- function(object, halfWindowSize = 2L,
                                refineMz = c("none", "kNeighbors",
                                             "kNeighbours",
                                             "descendPeak"),
-                               ...) {
+                               msLevel., ...) {
+    if (!missing(msLevel.)) {
+        if (!(msLevel(object) %in% msLevel.))
+            return(object)
+    }
     if (isEmpty(object)) {
         warning("Your spectrum is empty. Nothing to pick.")
         return(object)

--- a/R/methods-MSnExp.R
+++ b/R/methods-MSnExp.R
@@ -238,14 +238,16 @@ setMethod("pickPeaks", "MSnExp",
                    method = c("MAD", "SuperSmoother"),
                    SNR = 0L, refineMz = c("none", "kNeighbors", "kNeighbours",
                                           "descendPeak"),
-                   ...) {
-              object <- logging(object, paste0("peak picking: ", method,
-                                               " noise estimation and ",
-                                               refineMz, " centroid m/z ",
-                                               "refinement"))
+                   msLevel. = unique(msLevel(object)), ...) {
+              object <- logging(
+                  object, paste0("peak picking: ", method, " noise estimation",
+                                 " and ", refineMz, " centroid m/z refinement",
+                                 " on spectra of MS level(s)",
+                                 paste0(msLevel., collapse = ", ")))
               pickPeaks_MSnExp(object, halfWindowSize = halfWindowSize,
                                method = match.arg(method), SNR = SNR,
-                               refineMz = match.arg(refineMz), ...)
+                               refineMz = match.arg(refineMz),
+                               msLevel. = msLevel., ...)
           })
 
 setMethod("estimateNoise", "MSnExp",

--- a/R/methods-OnDiskMSnExp.R
+++ b/R/methods-OnDiskMSnExp.R
@@ -781,7 +781,7 @@ setMethod("pickPeaks", "OnDiskMSnExp",
                    method = c("MAD", "SuperSmoother"),
                    SNR = 0L, refineMz = c("none", "kNeighbors", "kNeighbours",
                                           "descendPeak"),
-                   ...) {
+                   msLevel. = unique(msLevel(object)), ...) {
               method <- match.arg(method)
               refineMz <- match.arg(refineMz)
               ## If we're using an approach that combines spectra we have
@@ -791,13 +791,15 @@ setMethod("pickPeaks", "OnDiskMSnExp",
                                         halfWindowSize = halfWindowSize,
                                         SNR = SNR,
                                         ignoreCentroided = TRUE,
-                                        refineMz = refineMz, ...))
+                                        refineMz = refineMz,
+                                        msLevel. = msLevel., ...))
               object@spectraProcessingQueue <- c(object@spectraProcessingQueue,
                                                  list(ps))
-              object <- logging(object, paste0("peak picking: ", method,
-                                               " noise estimation and ",
-                                               refineMz, " centroid m/z ",
-                                               "refinement"))
+              object <- logging(
+                  object, paste0("peak picking: ", method, " noise estimation",
+                                 " and ", refineMz, " centroid m/z refinement",
+                                 " on spectra of MS level(s)",
+                                 paste0(msLevel., collapse = ", ")))
               object@processingData@smoothed <- TRUE
               fData(object)$centroided <- TRUE
               if (validObject(object))

--- a/R/methods-Spectra.R
+++ b/R/methods-Spectra.R
@@ -85,8 +85,9 @@ setMethod("show", "Spectra", function(object) {
 #' @param all For `clean`: if `FALSE` original 0-intensity values are retained
 #'   around peaks.
 #'
-#' @param msLevel. For `clean`, `removePeaks`, `filterMz`: optionally specify
-#'   the MS level of the spectra on which the operation should be performed.
+#' @param msLevel. For `clean`, `removePeaks`, `filterMz`, `pickPeaks`:
+#'   optionally specify the MS level(s) of the spectra on which the operation
+#'   should be performed.
 #'   For `filterMsLevels`: MS level(s) to which the `Spectra` should be reduced.
 #'
 #' @param method For `pickPeaks` and `smooth`: see [pickPeaks()] and [smooth()]
@@ -401,10 +402,12 @@ setMethod("pickPeaks", "Spectra", function(object, halfWindowSize = 3L,
                                            SNR = 0L,
                                            refineMz = c("none", "kNeighbors",
                                                         "kNeighbours",
-                                                        "descendPeak"), ...) {
+                                                        "descendPeak"),
+                                           msLevel. = unique(msLevel(object)),
+                                           ...) {
     object <- endoapply(object, pickPeaks, halfWindowSize = halfWindowSize,
                         method = match.arg(method), SNR = SNR,
-                        refineMz = refineMz, ...)
+                        refineMz = refineMz, msLevel. = msLevel., ...)
     if (validObject(object))
         object
 })

--- a/R/methods-Spectrum.R
+++ b/R/methods-Spectrum.R
@@ -245,10 +245,12 @@ setMethod("pickPeaks", "Spectrum",
           function(object, halfWindowSize = 3L,
                    method = c("MAD", "SuperSmoother"),
                    SNR = 0L, refineMz = c("none", "kNeighbors",
-                                          "kNeighbours", "descendPeak"), ...) {
+                                          "kNeighbours", "descendPeak"),
+                   msLevel. = msLevel(object), ...) {
               pickPeaks_Spectrum(object, halfWindowSize = halfWindowSize,
                                  method = match.arg(method), SNR = SNR,
-                                 refineMz = match.arg(refineMz), ...)
+                                 refineMz = match.arg(refineMz),
+                                 msLevel. = msLevel., ...)
           })
 
 setMethod("smooth", "Spectrum",
@@ -284,7 +286,7 @@ setMethod("isCentroided", "Spectrum",
 #' @aliases estimateMzResolution
 #'
 #' @description
-#' 
+#'
 #' `estimateMzResolution` estimates the m/z resolution of a profile-mode
 #' `Spectrum` (or of all spectra in an [MSnExp] or [OnDiskMSnExp] object.
 #' The m/z resolution is defined as the most frequent difference between a
@@ -302,7 +304,7 @@ setMethod("isCentroided", "Spectrum",
 #' @param object either a `Spectrum`, `MSnExp` or `OnDiskMSnExp` object.
 #'
 #' @param ... currently not used.
-#' 
+#'
 #' @return `numeric(1)` with the m/z resolution. If called on a `MSnExp` or
 #' `OnDiskMSnExp` a `list` of m/z resolutions are returned (one for
 #' each spectrum).

--- a/man/MSnExp-class.Rd
+++ b/man/MSnExp-class.Rd
@@ -187,7 +187,8 @@
     % See \code{\link{extractSpectra}} documentation for more details
     % and examples. }
     \item{pickPeaks}{\code{signature(object = "MSnExp")}: Performs the peak
-      picking to generate centroided spectra.
+      picking to generate centroided spectra. Parameter \code{msLevel.}
+      allows to restrict peak picking to spectra of certain MS level(s).
       See \code{\link{pickPeaks}} documentation for more
       details and examples. }
     \item{estimateNoise}{\code{signature(object = "MSnExp")}: Estimates

--- a/man/Spectra.Rd
+++ b/man/Spectra.Rd
@@ -91,7 +91,8 @@ Spectra(..., elementMetadata = NULL)
 
 \S4method{pickPeaks}{Spectra}(object, halfWindowSize = 3L,
   method = c("MAD", "SuperSmoother"), SNR = 0L, refineMz = c("none",
-  "kNeighbors", "kNeighbours", "descendPeak"), ...)
+  "kNeighbors", "kNeighbours", "descendPeak"),
+  msLevel. = unique(msLevel(object)), ...)
 
 \S4method{smooth}{Spectra}(x, method = c("SavitzkyGolay",
   "MovingAverage"), halfWindowSize = 2L, ...)
@@ -125,8 +126,9 @@ for the MGF file.}
 \item{all}{For \code{clean}: if \code{FALSE} original 0-intensity values are retained
 around peaks.}
 
-\item{msLevel.}{For \code{clean}, \code{removePeaks}, \code{filterMz}: optionally specify
-the MS level of the spectra on which the operation should be performed.
+\item{msLevel.}{For \code{clean}, \code{removePeaks}, \code{filterMz}, \code{pickPeaks}:
+optionally specify the MS level(s) of the spectra on which the operation
+should be performed.
 For \code{filterMsLevels}: MS level(s) to which the \code{Spectra} should be reduced.}
 
 \item{t}{For \code{removePeaks}: \code{numeric(1)} specifying the threshold below

--- a/tests/testthat/test_MSnExp.R
+++ b/tests/testthat/test_MSnExp.R
@@ -470,6 +470,13 @@ test_that("setAs,MSnExp,data.frame works", {
     expect_equal(unlist(intensity(res), use.names = FALSE), df$i)
 })
 
+test_that("pickPeaks,MSnExp works with msLevel", {
+    res <- pickPeaks(tmt_im_ms1_sub, msLevel = 2)
+    expect_identical(peaksCount(res), peaksCount(tmt_im_ms1_sub))
+    res <- pickPeaks(tmt_im_ms1_sub, msLevel = 1:3)
+    expect_true(all(peaksCount(res) < peaksCount(tmt_im_ms1_sub)))
+})
+
 test_that("pickPeaks,MSnExp works with refineMz", {
     ## Reduce the TMT erwinia data set to speed up processing on the full
     ## data.

--- a/tests/testthat/test_OnDiskMSnExp_other_methods.R
+++ b/tests/testthat/test_OnDiskMSnExp_other_methods.R
@@ -76,6 +76,14 @@ test_that("Compare OnDiskMSnExp and MSnExp pickPeaks", {
     names(pc) <- NULL
     names(pc2) <- NULL
     expect_identical(pc, pc2)
+
+    centroided(ondisk) <- FALSE
+    res <- pickPeaks(ondisk, msLevel = 1L)
+    expect_identical(peaksCount(filterMsLevel(res, 2)),
+                     peaksCount(filterMsLevel(ondisk, 2)))
+    expect_identical(peaksCount(pp2), peaksCount(filterMsLevel(res, 1)))
+    expect_identical(peaksCount(ondisk),
+                     peaksCount(pickPeaks(ondisk, msLevel = 3)))
 })
 
 ############################################################
@@ -221,14 +229,14 @@ test_that("pickPeaks,OnDiskMSnExp works with refineMz", {
     tmt_pk <- pickPeaks(tmt_erwinia_on_disk_ms1, refineMz = "descendPeak",
                         signalPercentage = 75)
     expect_equal(spctr_pk, tmt_pk[[1]])
-    
+
     ## Check if we can call method and refineMz and pass arguments to both
     spctr_pk <- pickPeaks(spctr, refineMz = "kNeighbors", k = 1,
                           method = "SuperSmoother", span = 0.9)
     tmt_pk <- pickPeaks(tmt_erwinia_on_disk_ms1, refineMz = "kNeighbors",
                         k = 1, method = "SuperSmoother", span = 0.9)
     expect_equal(spctr_pk, tmt_pk[[1]])
-    
+
     ## Check errors
     expect_error(pickPeaks(tmt_erwinia_on_disk_ms1, refineMz = "some_method"))
 })

--- a/tests/testthat/test_Spectrum.R
+++ b/tests/testthat/test_Spectrum.R
@@ -305,12 +305,13 @@ test_that(".spectrum_header works", {
     sp_1 <- tmt_erwinia_on_disk[[1]]
     sp_2 <- tmt_erwinia_on_disk[[2]]
 
-    hdr_1 <- .spectrum_header(sp_1)
+    hdr_1 <- MSnbase:::.spectrum_header(sp_1)
     hdr_1$seqNum <- 1L
     expect_true(all(colnames(hdr) %in% colnames(hdr_1)))
     cns <- colnames(hdr)
     cns <- cns[!(cns %in% c("basePeakMZ", "basePeakIntensity", "injectionTime",
-                            "filterString", "spectrumId"))]
+                            "filterString", "spectrumId",
+                            "scanWindowLowerLimit", "scanWindowUpperLimit"))]
     for (cn in cns)
         expect_equal(hdr[1, cn], hdr_1[1, cn])
 

--- a/tests/testthat/test_Spectrum.R
+++ b/tests/testthat/test_Spectrum.R
@@ -96,6 +96,8 @@ test_that("Peak picking", {
     expect_equal(suppressWarnings(pickPeaks(s2)), s2)
     centroided(s1) <- FALSE
     expect_equal(pickPeaks(s1), s2)
+    expect_equal(pickPeaks(s1, msLevel = 1), s1)
+    expect_equal(pickPeaks(s1, msLevel = c(2, 3)), s2)
 })
 
 test_that("Spectrum smoothing", {

--- a/tests/testthat/test_Spectrum.R
+++ b/tests/testthat/test_Spectrum.R
@@ -305,7 +305,7 @@ test_that(".spectrum_header works", {
     sp_1 <- tmt_erwinia_on_disk[[1]]
     sp_2 <- tmt_erwinia_on_disk[[2]]
 
-    hdr_1 <- MSnbase:::.spectrum_header(sp_1)
+    hdr_1 <- .spectrum_header(sp_1)
     hdr_1$seqNum <- 1L
     expect_true(all(colnames(hdr) %in% colnames(hdr_1)))
     cns <- colnames(hdr)

--- a/tests/testthat/test_methods-Spectra.R
+++ b/tests/testthat/test_methods-Spectra.R
@@ -238,6 +238,13 @@ test_that("pickPeaks,Spectra and smooth,Spectra works", {
     res <- pickPeaks(spl)
     expect_true(is(res, "Spectra"))
     expect_equal(res@listData, lapply(spctra, pickPeaks))
+    expect_true(all(peaksCount(res) < peaksCount(spl)))
+
+    res <- pickPeaks(spl, msLevel = 2:3)
+    expect_equal(peaksCount(res), peaksCount(spl))
+
+    res <- pickPeaks(spl, msLevel = 1:4)
+    expect_true(all(peaksCount(res) < peaksCount(spl)))
 
     expect_warning(res <- smooth(spl))
     expect_true(is(res, "Spectra"))

--- a/tests/testthat/test_writeMSData.R
+++ b/tests/testthat/test_writeMSData.R
@@ -60,7 +60,9 @@ test_that("writeMSData works", {
                                        "precursorScanNum", "acquisitionNum",
                                        "injectionTime", "spectrumId",
                                        "filterString",
-                                       "isolationWindowTargetMZ"))]
+                                       "isolationWindowTargetMZ",
+                                       "scanWindowLowerLimit",
+                                       "scanWindowUpperLimit"))]
     expect_equal(fd_out[, check_cols], fd_in[, check_cols])
     ## Again force check:
     expect_equal(unname(precursorCharge(odf_out)),


### PR DESCRIPTION
- Add parameter `msLevel` to `pickPeaks` (issue #478)
- Fixes for the new `mzR` version (2.17.4)