### PR TITLE
feat: add parameter `weighted` to `consensusSpectrum`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,9 @@
 
 MSnbase 2.11.7
 
-- Add parameter `weighted` to `consensusSpectrum` <2019-09-12 Thu>.
+- Add parameter `weighted` to `consensusSpectrum` and change the default from
+  reporting the intensity-weighted mean of m/z values for consensus peaks to
+  reporting the m/z of the largest peak <2019-09-12 Thu>.
 
 MSnbase 2.11.6
 

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 
 MSnbase 2.11.7
 
-- Nothing yet
+- Add parameter `weighted` to `consensusSpectrum` <2019-09-12 Thu>.
 
 MSnbase 2.11.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## MSnbase 2.11.7
 
-- Add parameter `weighted` to `consensusSpectrum` <2019-09-12 Thu>.
+- Add parameter `weighted` to `consensusSpectrum` and change the default from
+  reporting the intensity-weighted mean of m/z values for consensus peaks to
+  reporting the m/z of the largest peak <2019-09-12 Thu>.
 
 ## MSnbase 2.11.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## MSnbase 2.11.7
 
-- Nothing yet
+- Add parameter `weighted` to `consensusSpectrum` <2019-09-12 Thu>.
 
 ## MSnbase 2.11.6
 

--- a/R/functions-Spectrum.R
+++ b/R/functions-Spectrum.R
@@ -1166,8 +1166,8 @@ meanMzInts <- function(x, ..., intensityFun = base::mean, weighted = FALSE,
 #'
 #' @param weighted `logical(1)` whether the m/z of the aggregated peak
 #'     represents the intensity-weighted average of the m/z values of all peaks
-#'     of the peak group. If `FALSE`, the m/z of the peak with the **largest**
-#'     intensity is reported.
+#'     of the peak group. If `FALSE` (the default), the m/z of the peak with
+#'     the **largest** intensity is reported.
 #'
 #' @param ... additional arguments to be passed to `intensityFun`.
 #'
@@ -1235,11 +1235,11 @@ consensusSpectrum <- function(x, mzd, minProp = 0.5, intensityFun = base::max,
     ints <- split(ints, mz_groups)
     keep <- lengths(mzs) >= (length(x) * minProp)
     if (any(keep)) {
-        if (weighted)
+        if (weighted) {
+            wm <- stats::weighted.mean
             xnew@mz <- mapply(mzs[keep], ints[keep], FUN = function(mz_vals, w)
-                stats::weighted.mean(mz_vals, w + 1, na.rm = TRUE),
-                USE.NAMES = FALSE)
-        else
+                wm(mz_vals, w + 1, na.rm = TRUE), USE.NAMES = FALSE)
+        } else
             xnew@mz <- mapply(mzs[keep], ints[keep],
                               FUN = function(mzv, intv) mzv[which.max(intv)],
                               USE.NAMES = FALSE)

--- a/R/methods-Spectra.R
+++ b/R/methods-Spectra.R
@@ -430,7 +430,7 @@ setMethod("smooth", "Spectra", function(x, method = c("SavitzkyGolay",
 #' or [Spectra-class] object applying the summarization function `fun` to sets
 #' of spectra defined by a factor (`fcol` parameter). The resulting combined
 #' spectrum for each set contains metadata information (present in `mcols` and
-#' all spectrum information other than `mz` and `intensity`) from the first
+#' all spectrum information other than `mz` and `intensity`) from the **first**
 #' spectrum in each set.
 #'
 #' Combining of spectra for [MSnExp-class] or [OnDiskMSnExp-class] objects is

--- a/man/combineSpectra.Rd
+++ b/man/combineSpectra.Rd
@@ -44,7 +44,7 @@ are taken from the first \code{Spectrum} in each set.
 or \linkS4class{Spectra} object applying the summarization function \code{fun} to sets
 of spectra defined by a factor (\code{fcol} parameter). The resulting combined
 spectrum for each set contains metadata information (present in \code{mcols} and
-all spectrum information other than \code{mz} and \code{intensity}) from the first
+all spectrum information other than \code{mz} and \code{intensity}) from the \strong{first}
 spectrum in each set.
 
 Combining of spectra for \linkS4class{MSnExp} or \linkS4class{OnDiskMSnExp} objects is

--- a/man/consensusSpectrum.Rd
+++ b/man/consensusSpectrum.Rd
@@ -5,7 +5,7 @@
 \title{Combine spectra to a consensus spectrum}
 \usage{
 consensusSpectrum(x, mzd, minProp = 0.5, intensityFun = base::max,
-  ppm = 0, ...)
+  ppm = 0, weighted = FALSE, ...)
 }
 \arguments{
 \item{x}{\code{list} of \linkS4class{Spectrum} objects (either \linkS4class{Spectrum1} or
@@ -29,6 +29,11 @@ reported.}
 
 \item{ppm}{\code{numeric(1)} allowing to perform a m/z dependent grouping of mass
 peaks. See details for more information.}
+
+\item{weighted}{\code{logical(1)} whether the m/z of the aggregated peak
+represents the intensity-weighted average of the m/z values of all peaks
+of the peak group. If \code{FALSE}, the m/z of the peak with the \strong{largest}
+intensity is reported.}
 
 \item{...}{additional arguments to be passed to \code{intensityFun}.}
 }

--- a/man/consensusSpectrum.Rd
+++ b/man/consensusSpectrum.Rd
@@ -32,8 +32,8 @@ peaks. See details for more information.}
 
 \item{weighted}{\code{logical(1)} whether the m/z of the aggregated peak
 represents the intensity-weighted average of the m/z values of all peaks
-of the peak group. If \code{FALSE}, the m/z of the peak with the \strong{largest}
-intensity is reported.}
+of the peak group. If \code{FALSE} (the default), the m/z of the peak with
+the \strong{largest} intensity is reported.}
 
 \item{...}{additional arguments to be passed to \code{intensityFun}.}
 }


### PR DESCRIPTION
- Add parameter `weighted` to `consensusSpectrum` to allow enabling/disabling
  the intensity-weighted calculation of the reported m/z values.