### PR TITLE
Initial support for mzTab-M 2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Changes in 2.13.5
 - Nothing yet
+- Support reading of MzTab-M 2.0 format
 
 ## Changes in 2.13.4
 - Fix failing unit test: in R 4.0, data.frames not don't cast strings

--- a/R/DataClasses.R
+++ b/R/DataClasses.R
@@ -351,6 +351,8 @@ setClass("MSnSet",
                        Peptides = "data.frame",
                        PSMs = "data.frame",
                        SmallMolecules = "data.frame",
+                       MoleculeFeatures = "data.frame",
+                       MoleculeEvidence = "data.frame",                       
                        Comments = "character"))
 
 ##################################################################

--- a/R/MzTab.R
+++ b/R/MzTab.R
@@ -44,6 +44,8 @@ setMethod("psms", "MzTab",
           function(object, ...) object@PSMs)
 
 smallMolecules <- function(x) x@SmallMolecules
+moleculeFeatures <- function(x) x@MoleculeFeatures
+moleculeEvidence <- function(x) x@MoleculeEvidence
 
 comments <- function(x) x@Comments
 
@@ -76,14 +78,15 @@ MzTab <- function(file) {
     ## metadata afterwards
     res <- setNames(
         lapply(
-            linesByType[c("MT", "PR", "PE", "PS", "SM")],
+            linesByType[c("MT", "PR", "PE", "PS", "SM", "SF", "SE")],
             function(x) {
                 if (length(x) == 0) return(data.frame())
                 return(read.delim(text = x,
                                   na.strings = c("", "null"),
                                   stringsAsFactors = FALSE)[,-1])
             }),
-        c("Metadata", "Proteins", "Peptides", "PSMs", "SmallMolecules"))
+        c("Metadata", "Proteins", "Peptides", "PSMs", "SmallMolecules",
+          "MoleculeFeatures", "MoleculeEvidence"))
     
     res[["Metadata"]] <- reshapeMetadata(res[["Metadata"]])
 
@@ -93,6 +96,8 @@ MzTab <- function(file) {
            Peptides = res[["Peptides"]],
            PSMs = res[["PSMs"]],
            SmallMolecules = res[["SmallMolecules"]],
+           MoleculeFeatures = res[["MoleculeFeatures"]],
+           MoleculeEvidence = res[["MoleculeEvidence"]],
            Comments = comments)
 
 }

--- a/tests/testthat/test_MzTab.R
+++ b/tests/testthat/test_MzTab.R
@@ -1,6 +1,7 @@
 context("MzTab class")
 
 baseUrl <- "https://raw.githubusercontent.com/HUPO-PSI/mzTab/master/examples/1_0-Proteomics-Release/"
+baseUrlM <- "https://raw.githubusercontent.com/HUPO-PSI/mzTab/master/examples/2_0-Metabolomics_Release/"
 
 test_that("MzTab creation and accessors", {
     fl <- "iTRAQ_CQI.mzTab"
@@ -26,6 +27,32 @@ test_that("MzTab creation and accessors", {
     expect_identical(dim(smallMolecules(xx)), c(0L, 0L))
     expect_is(comments(xx), "character")
     expect_identical(length(comments(xx)), 5L)
+})
+
+test_that("MzTab-M creation and accessors", {
+    fl <- "MTBLS263.mztab"
+    fl <- file.path(baseUrlM, fl)
+    xx <- MzTab(fl)
+    expect_true(validObject(xx))
+    expect_null(show(xx))
+    ## Accessors
+    expect_is(metadata(xx), "list")
+    ## expect_identical(length(metadata(xx)), 64L)
+    ## expect_identical(mzTabMode(xx), metadata(xx)$`mzTab-mode`)
+    ## expect_identical(mzTabMode(xx), "Complete")
+    ## expect_identical(mzTabType(xx), metadata(xx)$`mzTab-type`)
+    ## expect_identical(mzTabType(xx), "Quantification")
+    ## expect_identical(fileName(xx), fl)
+    ## expect_is(proteins(xx), "data.frame")
+    ## expect_identical(dim(proteins(xx)), c(5L, 55L))
+    ## expect_is(peptides(xx), "data.frame")
+    ## expect_identical(dim(peptides(xx)), c(0L, 0L))
+    ## expect_is(psms(xx), "data.frame")
+    ## expect_identical(dim(psms(xx)), c(36L, 18L))
+    ## expect_is(smallMolecules(xx), "data.frame")
+    ## expect_identical(dim(smallMolecules(xx)), c(0L, 0L))
+    ## expect_is(comments(xx), "character")
+    ## expect_identical(length(comments(xx)), 5L)
 })
 
 test_that("Conversion to MSnSetList", {


### PR DESCRIPTION
Hi, my Easter present is an initial support for mzTab-M,
simply extending the list of supported sections and extending 
the slots in the MzTab class. Couldn't test locally, as my laptop 
generates a SEGV when installing, but that's probably my borked R installation. 
Will add improved testing soon. Yours, Steffen