### PR TITLE
Dont fix illegal colnames when reading mzTab, closes #501

### DIFF
--- a/R/MzTab.R
+++ b/R/MzTab.R
@@ -84,6 +84,7 @@ MzTab <- function(file) {
                 if (length(x) == 0) return(data.frame())
                 return(read.delim(text = x,
                                   na.strings = c("", "null"),
+                                  check.names = FALSE,
                                   stringsAsFactors = FALSE)[,-1])
             }),
         c("Metadata", "Proteins", "Peptides", "PSMs", "SmallMolecules",


### PR DESCRIPTION
That's now the cherry-picked fix for the column names. Yours, Steffen