### PR TITLE
Fix import of mzTab from MS-Dial

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -121,6 +121,8 @@ export(MSnSet,
        ## MzTab
        MzTab,
        smallMolecules,
+       moleculeFeatures,
+       moleculeEvidence,
        comments,
        mzTabMode,
        mzTabType,

--- a/R/MzTab.R
+++ b/R/MzTab.R
@@ -99,6 +99,7 @@ MzTab <- function(file) {
                 if (length(x) == 0) return(data.frame())
                 return(read.delim(text = x,
                                   header = ifelse(all(grepl("^MTD", x)), FALSE, TRUE), ## MTD has no header
+                                  row.names = NULL,
                                   na.strings = c("", "null"),
                                   check.names = FALSE,
                                   stringsAsFactors = FALSE)[,-1])

--- a/man/MzTab-class.Rd
+++ b/man/MzTab-class.Rd
@@ -12,6 +12,8 @@
 \alias{psms,MzTab-method}
 \alias{comments}
 \alias{smallMolecules}
+\alias{moleculeFeatures}
+\alias{moleculeEvidence}
 \alias{mzTabMode}
 \alias{mzTabType}
 \alias{coerce,MzTab,MSnSetList-method}
@@ -103,7 +105,11 @@
     \item{psms}{\code{signature(object = "MzTab")}: returns the
       PSMs \code{data.frame}. }
     \item{smallMolecules}{\code{signature(object = "MzTab")}: returns
-      the small molecules \code{data.frame}. }
+      the small molecules (SML) \code{data.frame}. }
+    \item{moleculeFeatures}{\code{signature(object = "MzTab")}: returns
+      the small molecules features (SMF) \code{data.frame}. }
+    \item{moleculeEvidence}{\code{signature(object = "MzTab")}: returns
+      the small molecule identification evidence (SME) \code{data.frame}. }
     \item{comments}{\code{signature(object = "MzTab")}: returns the
       comments. }
   }
@@ -113,7 +119,8 @@
 \references{
 
   The mzTab format is a light-weight, tab-delimited file format for
-  proteomics data. See https://github.com/HUPO-PSI/mzTab for details and
+  proteomics data. Version mzTab 1.0 is aimed at proteomics, mzTab-M 2.0
+  was adapted to metabolomics. See https://github.com/HUPO-PSI/mzTab for details and
   specifications.
 
   Griss J, Jones AR, Sachsenberg T, Walzer M, Gatto L, Hartler J,
@@ -125,7 +132,11 @@
   audience. Mol Cell Proteomics. 2014 Oct;13(10):2765-75. doi:
   10.1074/mcp.O113.036681. Epub 2014 Jun 30. PubMed PMID: 24980485;
   PubMed Central PMCID: PMC4189001.
-  
+
+  Hoffmann N, Rein J, Sachsenberg T, et al. mzTab-M: A Data Standard
+  for Sharing Quantitative Results in Mass Spectrometry Metabolomics.
+  Anal Chem. 2019;91(5):3302‐3310. doi:10.1021/acs.analchem.8b04310
+  PubMed PMID: 30688441; PubMed Central PMCID: PMC6660005.
 }
 
 \author{

--- a/tests/testthat/test_MzTab.R
+++ b/tests/testthat/test_MzTab.R
@@ -66,6 +66,45 @@ test_that("MzTab-M creation and accessors", {
     expect_identical(length(comments(xx)), 0L)
 })
 
+test_that("MzTab-M MS-Dial import", {
+  fl <- "msdial/lcmsms_swath_lipid_height_mzTab.txt"
+  fl <- file.path(baseUrlM, fl)
+  xx <- MzTab(fl)
+  expect_true(validObject(xx))
+  expect_null(show(xx))
+  
+  ## Accessors
+  expect_is(metadata(xx), "list")
+  expect_identical(length(metadata(xx)), 178L)
+  
+  ## In mzTab-M 2.0 metadata(xx)$`mzTab-mode`=="NULL"
+  expect_identical(mzTabMode(xx), metadata(xx)$`mzTab-mode`)
+  
+  ## In mzTab-M 2.0 metadata(xx)$`mzTab-type`=="NULL"
+  expect_identical(mzTabType(xx), metadata(xx)$`mzTab-type`)
+  
+  expect_identical(fileName(xx), fl)
+  expect_is(proteins(xx), "data.frame")
+  expect_identical(dim(proteins(xx)), c(0L, 0L))
+  
+  expect_is(peptides(xx), "data.frame")
+  expect_identical(dim(peptides(xx)), c(0L, 0L))
+  
+  expect_is(psms(xx), "data.frame")
+  expect_identical(dim(psms(xx)), c(0L, 0L))
+  
+  expect_is(smallMolecules(xx), "data.frame")
+  expect_identical(dim(smallMolecules(xx)), c(1172L, 47L))
+  expect_is(moleculeFeatures(xx), "data.frame")
+  expect_identical(dim(moleculeFeatures(xx)), c(1172L, 34L))
+  expect_is(moleculeEvidence(xx), "data.frame")
+  expect_identical(dim(moleculeEvidence(xx)), c(199L, 23L))
+  
+  expect_is(comments(xx), "character")
+  expect_identical(length(comments(xx)), 1L)
+})
+
+
 test_that("MzTab reading and writing", {
     fl <- "iTRAQ_CQI.mzTab"
     fl <- file.path(baseUrl, fl)


### PR DESCRIPTION
The particular flavor of MS-Dial causes `read.delim()` to try adding rownames, 
which are `SME` for all rows, which just fails. So enforce that rownames are 
simply enumerated numbers and not taken from file. My R is still borked, 
so I couldn't run R CMD check yet. Yours, Steffen 