### PR TITLE
refactor: add splitByFile,OnDiskMSnExp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -122,7 +122,7 @@ BugReports: https://github.com/lgatto/MSnbase/issues
 URL: https://lgatto.github.io/MSnbase
 biocViews: ImmunoOncology, Infrastructure, Proteomics, MassSpectrometry,
     QualityControl, DataImport
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Collate:
     'AllClassUnions.R'
     'AllGenerics.R'

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -35,7 +35,7 @@ importFrom(ggplot2, geom_histogram, geom_text, geom_line, geom_point,
 importFrom(MALDIquant, binPeaks, match.closest) ## only using ::: functions
 importFrom(S4Vectors, isEmpty, metadata, DataFrame, replaceROWS, SimpleList,
            endoapply)
-importMethodsFrom(S4Vectors, showAsCell, "mcols<-", mcols, split)
+importMethodsFrom(S4Vectors, showAsCell, "mcols<-", mcols, split, extractROWS)
 importClassesFrom(S4Vectors, SimpleList)
 importFrom(MASS, rlm)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # MSnbase 2.15
 
 ## Changes in 2.15.4
-- Nothing yet
+- Add splitByFile,OnDiskMSnExp method to provide a more efficient splitting.
 
 ## Changes in 2.15.3
 - Rename Spectra class to MSpectra.

--- a/R/functions-OnDiskMSnExp.R
+++ b/R/functions-OnDiskMSnExp.R
@@ -174,7 +174,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 }
 
 #' @title Apply a function to spectra loaded from a single file
-#' 
+#'
 #' @description This function creates `Spectrum1` and `Spectrum2` objects for
 #'     the specicied spectra in one file and applies the provided function to
 #'     each of them.
@@ -186,14 +186,14 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 #'     After that, depending on the arguments `queue` and `APPLYFUN` a `lapply`
 #'     call is performed applying the respective calls to each spectrum. Finally
 #'     results are ordered and returned.
-#' 
+#'
 #' @note Using the C constructor that takes all values at once and creates a
 #'     list of `Spectrum1` objects, applies processing steps, applies the
 #'     provided function and returns its results - or the list of
 #'     `Spectrum1` objects if `APPLYFUN = NULL`.
 #'
 #'     Note: enforces ordering of M/Z-intensity pairs by M/Z.
-#' 
+#'
 #' @param fData: either a full `data.frame` (returned by `fData(OnDiskMSnExp))`
 #'     or a sub-set forspecific spectra. The data.frame should ONLY
 #'     CONTAIN VALUES FOR SPECTRA OF ONE FILE!
@@ -203,23 +203,23 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 #' @param queue: `object@spectraProcessingQueue`; if `lenght > 0` all
 #'     processing steps will be applied to the created spectrum
 #'     objects.
-#' 
+#'
 #' @param APPLYFUN: the function to be applied to the spectrum objects
 #'     (such as `ionCount` etc). If `NULL` the function returns the list of
 #'     spectrum objects.
-#' 
+#'
 #' @param fastLoad: `logical(1)` whether reading the spectras' header data
 #'     should be omitted prior to retrieving the data (i.e. skip the
 #'     `mzR::header` call before calling `mzR::peaks`. The former call might be
 #'     required on some systems (so far macOS) for some files.
-#' 
+#'
 #' @param ...: additional arguments for the APPLYFUN
 #'
 #' @return `list` with either spectrum objects or the results of the function
 #'     provided with argument `APPLYFUN`.
 #'
 #' @author Johannes Rainer
-#' 
+#'
 #' @noRd
 #'
 #' @md
@@ -375,7 +375,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 #'     enforces also ordering of M/Z-intensity pairs by M/Z.
 #'     Performance wise, this function is fast on gzipped mzML files but should
 #'     not be used on CDF files!
-#' 
+#'
 #' @param fData: either a full `data.frame` (returned by `fData(OnDiskMSnExp))`
 #'     or a sub-set forspecific spectra. The data.frame should ONLY
 #'     CONTAIN VALUES FOR SPECTRA OF ONE FILE!
@@ -385,23 +385,23 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 #' @param queue: `object@spectraProcessingQueue`; if `lenght > 0` all
 #'     processing steps will be applied to the created spectrum
 #'     objects.
-#' 
+#'
 #' @param APPLYFUN: the function to be applied to the spectrum objects
 #'     (such as `ionCount` etc). If `NULL` the function returns the list of
 #'     spectrum objects.
-#' 
+#'
 #' @param fastLoad: `logical(1)` whether reading the spectras' header data
 #'     should be omitted prior to retrieving the data (i.e. skip the
 #'     `mzR::header` call before calling `mzR::peaks`. The former call might be
 #'     required on some systems (so far macOS) for some files.
-#' 
+#'
 #' @param ...: additional arguments for the APPLYFUN
 #'
 #' @return `list` with either spectrum objects or the results of the function
 #'     provided with argument `APPLYFUN`.
 #'
 #' @author Johannes Rainer
-#' 
+#'
 #' @noRd
 #' @md
 .applyFun2IndividualSpectraOfFile <- function(fData, filenames,
@@ -499,7 +499,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 #' @note x has to be an MSnExp or OnDiskMSnExp object. The function is optimized
 #'     for OnDiskMSnExp objects such that extraction is performed in parallel
 #'     for each file.
-#' 
+#'
 #' @param rt \code{matrix} with two columns and number of rows corresponding to
 #'     the number of ranges to extract. If the number of columns of the matrix
 #'     is not equal to 2, \code{range} is called on each row.
@@ -516,7 +516,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 #'
 #' @param msLevel \code{integer(1)} ensuring that the chromatogram is extracted
 #'     only for a specified MS level.
-#' 
+#'
 #' @return A \code{matrix} with the \code{Chromatogram} objects with rows
 #'     corresponding to ranges and columns to files/samples. \code{result[, 1]}
 #'     will thus return a \code{list} of \code{Chromatogram} objects for the
@@ -545,7 +545,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
         rt <- matrix(c(-Inf, Inf), nrow = 1)
     if (missing(mz))
         mz <- matrix(c(-Inf, Inf), nrow = 1)
-    ## Calculate the range for each row in rt 
+    ## Calculate the range for each row in rt
     if (ncol(rt) != 2)
         rt <- t(apply(rt, MARGIN = 1, range))
     ## Replicate if nrow rt is 1 to match nrow of mz.
@@ -676,7 +676,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
 ##' estimates mode from the data, but is limited to data stemming from
 ##' mzML files which are still available in their original location
 ##' (and accessed with `fileNames(x)`).
-##' 
+##'
 ##' @title Get mode from mzML data file
 ##' @param x An object of class [OnDiskMSnExp-class].
 ##' @return A named `logical` vector of the same length as `x`.
@@ -710,3 +710,37 @@ isCentroidedFromFile <- function(x) {
     res[featureNames(x)]
 }
 
+#' @description small helper function to efficiently split an OnDiskMSnExp by
+#'     file avoiding costly validation calls.
+#'
+#' @author Johannes Rainer
+#'
+#' @noRd
+.on_disk_split_by_file <- function(x) {
+    a <- new("OnDiskMSnExp")
+    expd <- new("MIAPE")
+    procd <- x@processingData
+    create_object <- function(i, x) {
+        slot(expd, "instrumentManufacturer", check = FALSE) <-
+            x@experimentData@instrumentManufacturer[i]
+        slot(expd, "instrumentModel", check = FALSE) <-
+            x@experimentData@instrumentModel[i]
+        slot(expd, "ionSource", check = FALSE) <- x@experimentData@ionSource[i]
+        slot(expd, "analyser", check = FALSE) <- x@experimentData@analyser[i]
+        slot(expd, "detectorType", check = FALSE) <-
+            x@experimentData@detectorType[i]
+        slot(procd, "files", check = FALSE) <- x@processingData@files[i]
+        slot(a, "processingData", check = FALSE) <- procd
+        slot(a, "featureData", check = FALSE) <- extractROWS(
+            x@featureData, which(x@featureData$fileIdx == i))
+        if (!nrow(a@featureData))
+            stop("No spectra present.", call. = FALSE)
+        a@featureData$fileIdx <- 1L
+        slot(a, "experimentData", check = FALSE) <- expd
+        slot(a, "spectraProcessingQueue", check = FALSE) <-
+            x@spectraProcessingQueue
+        slot(a, "phenoData", check = FALSE) <- x@phenoData[i, , drop = FALSE]
+        a
+    }
+    lapply(seq_along(fileNames(x)), create_object, x = x)
+}

--- a/R/methods-OnDiskMSnExp.R
+++ b/R/methods-OnDiskMSnExp.R
@@ -928,3 +928,7 @@ setMethod("isolationWindowUpperMz", "OnDiskMSnExp", function(object) {
                             fData(object)$isolationWindowUpperOffset)
     rep(NA_real_, length(object))
 })
+
+setMethod("splitByFile", c("OnDiskMSnExp", "factor"), function(object, f) {
+    .on_disk_split_by_file(object)
+})

--- a/man/MSnExp-class.Rd
+++ b/man/MSnExp-class.Rd
@@ -77,6 +77,7 @@
 
 \alias{splitByFile}
 \alias{splitByFile,MSnExp,factor-method}
+\alias{splitByFile,OnDiskMSnExp,factor-method}
 
 \alias{coerce,MSnExp,data.frame-method}
 \alias{as.data.frame.MSnExp}

--- a/tests/testthat/test_OnDiskMSnExp.R
+++ b/tests/testthat/test_OnDiskMSnExp.R
@@ -293,10 +293,9 @@ test_that("spectrapply,OnDiskMSnExp", {
 
 test_that("splitByFile,OnDiskMSnExp", {
     od <- microtofq_on_disk_ms1
-    expect_error(splitByFile(od, f = factor(1:3)))
-    spl <- splitByFile(od, f = factor(c("b", "a")))
-    expect_equal(pData(spl[[1]]), pData(filterFile(od, 2)))
-    expect_equal(pData(spl[[2]]), pData(filterFile(od, 1)))
+    spl <- splitByFile(od, f = factor(c("a", "b")))
+    expect_equal(pData(spl[[1]]), pData(filterFile(od, 1)))
+    expect_equal(pData(spl[[2]]), pData(filterFile(od, 2)))
 })
 
 test_that("chromatogram,OnDiskMSnExp works", {
@@ -444,4 +443,13 @@ test_that("combineSpectra,MSnExp works with OnDiskMSnExp", {
     res <- combineSpectra(filterRt(sciex, c(10, 20)))
     expect_true(is(res, "MSnExp"))
     expect_true(length(res) == 2)
+})
+
+test_that(".on_disk_split_by_file works", {
+    res <- .on_disk_split_by_file(sciex)
+    expect_equal(length(res), 2)
+    expect_equal(featureData(res[[1]]), featureData(filterFile(sciex, 1L)))
+    expect_equal(featureData(res[[2]]), featureData(filterFile(sciex, 2L)))
+    expect_equal(phenoData(res[[1]]), phenoData(filterFile(sciex, 1L)))
+    expect_equal(phenoData(res[[2]]), phenoData(filterFile(sciex, 2L)))
 })


### PR DESCRIPTION
- Add the splitByFile,OnDiskMSnExp to provide a faster, more efficient splitting
  of OnDiskMSnExp objects that avoids unnecessary validation calls.

With this update `chromatogram` calls become faster for large `OnDiskMSnExp` objects.