### PR TITLE
refactor: add parameter ppm to combineSpectraMovingWindow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # MSnbase 2.15
 
 ## Changes in 2.15.5
-- Nothing yet.
+- `combineSpectraMovingWindow` gains parameter `ppm` to allow definition of m/z
+  relative differences.
 
 ## Changes in 2.15.4
 - Add splitByFile,OnDiskMSnExp method to provide a more efficient splitting.

--- a/man/combineSpectraMovingWindow.Rd
+++ b/man/combineSpectraMovingWindow.Rd
@@ -11,6 +11,7 @@ combineSpectraMovingWindow(
   mzd = NULL,
   timeDomain = FALSE,
   weighted = FALSE,
+  ppm = 0,
   BPPARAM = bpparam()
 )
 }
@@ -41,6 +42,11 @@ also be estimated on the square root of m/z values if
 \item{weighted}{\code{logical(1)} whether m/z values per m/z group should be
 aggregated with an intensity-weighted mean. The default is to report
 the mean m/z.}
+
+\item{ppm}{\code{numeric(1)} to define an m/z relative deviation. Note that if
+only \code{ppm} should be considered but not \code{mzd}, \code{mzd} should be set to
+\code{0} (i.e. \code{mzd = 0}). This parameter is directly passed to
+\code{\link[=meanMzInts]{meanMzInts()}}.}
 
 \item{BPPARAM}{parallel processing settings.}
 }


### PR DESCRIPTION
- Add parameter `ppm` to `combineSpectraMovingWindow` (issue #521).