### PR TITLE
Fixed some consistency in the reporting.

### DIFF
--- a/R/methods-filters.R
+++ b/R/methods-filters.R
@@ -7,9 +7,9 @@ setMethod("filterMsLevel", "MSnExp",
               msLevel. <- as.numeric(msLevel.)
               object <- object[msLevel(object) %in% msLevel.]
               object <- logging(object,
-                                paste("Filter: select MS level(s)",
+                                paste0("Filter: select MS level(s) ",
                                       paste(unique(msLevel.),
-                                            collapse = " ")))
+                                            collapse = " "), "."))
               object
           })
 
@@ -19,7 +19,7 @@ setMethod("filterPolarity", "MSnExp",
               msLevel. <- as.numeric(polarity.)
               object <- object[polarity(object) %in% polarity.]
               object <- logging(object,
-                                paste0("Filter: select polarity",
+                                paste0("Filter: select polarity ",
                                 polarity., "."))
               object
           })


### PR DESCRIPTION
Another important contribution...

Notice the inconsistent ending with "." and the missing space for polarity.

```r
Data loaded [Mon Sep 21 13:34:02 2020] 
Filter: select MS level(s) 1 2 [Mon Sep 21 13:34:02 2020] 
Filter: select MS level(s) 2 [Mon Sep 21 14:18:19 2020] 
Filter: select polarity1. [Mon Sep 21 14:18:19 2020] 
Filter: select by 89 acquisition number(s) in 1 file(s). [Mon Sep 21 14:18:19 2020] 
MSnbase version: 2.14.2

```