### PR TITLE
Enable "fast load" also on macOS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.19.3
+Version: 2.21.1
 Description: MSnbase provides infrastructure for manipulation,
              processing and visualisation of mass spectrometry and
              proteomics data, ranging from raw to quantitative and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
+# MSnbase 2.21
+
+## Changes in 2.21.1
+
+- Change default for MSnbase fast load variable: set to `TRUE` also on macOS.
+
 # MSnbase 2.19
-
-## Changes in 2.19.3
-
-- Nothing yet.
 
 ## Changes in 2.19.2
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,8 +17,9 @@
     ##     sortMeth <- "radix"
     fast_load <- TRUE
     ## Disable "fast reading" on macOS. See issue #170
-    if (Sys.info()["sysname"] == "Darwin")
-        fast_load <- FALSE
+    ## Enabling fast reading also on macOS to avoid spurious errors.
+    ## if (Sys.info()["sysname"] == "Darwin")
+    ##     fast_load <- FALSE
     msOps <- list(PARALLEL_THRESH = 1000,
                   fastLoad = fast_load,      # disable reading header before peaks.
                   ## sortMethod = sortMeth,


### PR DESCRIPTION
Reading the header information for the last spectrum before importing the peaks matrix led to random errors on recent macOS/R versions - although this fix was introduces years back to avoid exactly those errors. This PR changes the default on macOS - Windows and linux installation are unaffected (always used *fast load = TRUE*).