### PR TITLE
fix: ensure similarity matrix of compareChromatograms is symmetric

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.21.1
+Version: 2.21.2
 Description: MSnbase provides infrastructure for manipulation,
              processing and visualisation of mass spectrometry and
              proteomics data, ranging from raw to quantitative and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MSnbase 2.21
 
+## Changes in 2.21.2
+
+- Fix bug in `compareChromatograms` that creates a non-symmetric similarity
+  matrix.
+
 ## Changes in 2.21.1
 
 - Change default for MSnbase fast load variable: set to `TRUE` also on macOS.

--- a/R/methods-MChromatograms.R
+++ b/R/methods-MChromatograms.R
@@ -686,11 +686,11 @@ setMethod("compareChromatograms",
         for (j in seq_len(ny)) {
             if (i > j)
                 next
-            m[i, j] <- compareChromatograms(x[[i]], y[[j]], ALIGNFUN = ALIGNFUN,
-                                            ALIGNFUNARGS = ALIGNFUNARGS,
-                                            FUN = FUN, FUNARGS = FUNARGS)
+            m[j, i] <- m[i, j] <- compareChromatograms(
+                           x[[i]], y[[j]], ALIGNFUN = ALIGNFUN,
+                           ALIGNFUNARGS = ALIGNFUNARGS,
+                           FUN = FUN, FUNARGS = FUNARGS)
         }
     }
-    m[lower.tri(m)] <- m[upper.tri(m)]
     m
 }


### PR DESCRIPTION
- Fix bug in `compareChromatograms` that returns a non-symmetric similarity
  matrix.