### PR TITLE
fix: adapt to mzR version 2.29.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.21.4
+Version: 2.21.5
 Description: MSnbase provides infrastructure for manipulation,
              processing and visualisation of mass spectrometry and
              proteomics data, ranging from raw to quantitative and
@@ -69,7 +69,7 @@ Depends:
     methods,
     BiocGenerics (>= 0.7.1),
     Biobase (>= 2.15.2),
-    mzR (>= 2.19.6),
+    mzR (>= 2.29.3),
     S4Vectors,
     ProtGenerics (>= 1.27.2)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MSnbase 2.21
 
+## Changes in 2.21.5
+
+- Adapt to changes in `mzR` version 2.29.3.
+
 ## Changes in 2.21.4
 
 - Add `transformIntensity` function for `Chromatogram` and `MChromatograms`

--- a/R/map.R
+++ b/R/map.R
@@ -82,7 +82,7 @@ setMethod("plot", c("MSmap", "missing"),
                   scales.set <-
                       list(x = list(at = i, labels = formatRt(rtime(x)[i])),
                            y = list(at = j, labels = mz(x)[j]))
-              } 
+              }
               levelplot(log10(m),
                         scales = scales.set,
                         xlab = "Retention time",
@@ -97,7 +97,7 @@ setMethod("plot3D", "MSmap",
                       stop("The 'rgl' package needed. Install it with 'install.packages(\"rgl\")'.")
                   rgl::plot3d(dd$mz, dd$rt, dd$intensity, , type = "h",
                          xlab = "M/Z", ylab = "Retention time", zlab = "")
-              } else {                  
+              } else {
                   ms <- NULL ## get rid of 'no visible global function definition' note
                   par.set <- list(box.3d = list(lwd=.2))
                   cloud(intensity ~ mz + rt , data = dd,
@@ -108,7 +108,7 @@ setMethod("plot3D", "MSmap",
                             draw=TRUE),
                         aspect=c(.8, 1),
                         group = ms,
-                        zoom = 1, 
+                        zoom = 1,
                         par.settings = par.set,
                         axis.line = list(col = "transparent"),
                         xlab="M/Z", ylab="Retention time", zlab=NULL)
@@ -116,9 +116,9 @@ setMethod("plot3D", "MSmap",
           })
 
 
-setClassUnion("mzRraw", c("mzRpwiz", "mzRramp"))
+setClassUnion("mzRraw", c("mzRpwiz"))
 
-setMethod("MSmap", "mzRraw", 
+setMethod("MSmap", "mzRraw",
           function(object, scans, lowMz, highMz, resMz, hd,
                    zeroIsNA = FALSE) {
               if (missing(hd))
@@ -140,7 +140,7 @@ setMethod("MSmap", "mzRraw",
           })
 
 
-setMethod("MSmap", "OnDiskMSnExp", 
+setMethod("MSmap", "OnDiskMSnExp",
           function(object, scans, lowMz, highMz, resMz, hd = NULL,
                    zeroIsNA = FALSE) {
               ms1 <- which(msLevel(object) == 1)
@@ -162,4 +162,3 @@ setMethod("MSmap", "OnDiskMSnExp",
                      t = FALSE,
                      filename = fn)
           })
-

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -463,10 +463,6 @@ test_that(".openMSfile works", {
     res <- MSnbase:::.openMSfile(file)
     expect_true(is(res, "mzRpwiz"))
     close(res)
-    file <- system.file("microtofq", "MM14.mzdata", package = "msdata")
-    res <- MSnbase:::.openMSfile(file)
-    expect_true(is(res, "mzRramp"))
-    close(res)
 
     ## Errors
     expect_error(MSnbase:::.openMSfile(c("a", "b")))


### PR DESCRIPTION
- mzR >= 2.29.3 drops support for Ramp, this the respective backend is no longer
  available in mzR.