### PR TITLE
Fix declarations of centroided/smoothed setters for OnDiskMSnExp objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.25.2
+Version: 2.25.3
 Description: MSnbase provides infrastructure for manipulation,
              processing and visualisation of mass spectrometry and
              proteomics data, ranging from raw to quantitative and

--- a/R/methods-OnDiskMSnExp.R
+++ b/R/methods-OnDiskMSnExp.R
@@ -184,7 +184,7 @@ setMethod("centroided", "OnDiskMSnExp",
 
 setReplaceMethod("centroided",
                  signature(object = "OnDiskMSnExp", value = "logical"),
-                 function(object, value, msLevel.) {
+                 function(object, msLevel., ..., value) {
                      if (missing(msLevel.)) {
                          if (length(value) == 1)
                              value <- rep(value, length(object))
@@ -223,7 +223,7 @@ setMethod("smoothed", "OnDiskMSnExp",
 
 setReplaceMethod("smoothed",
                  signature(object = "OnDiskMSnExp", value = "logical"),
-                 function(object, value, msLevel.) {
+                 function(object, msLevel., ..., value) {
                      if (missing(msLevel.)) {
                          if (length(value) == 1)
                              value <- rep(value, length(object))


### PR DESCRIPTION
Salut Laurent,

With current R-devel (R 4.4), trying to install **MSnbase** <= 2.25.2 fails with error messages complaining about the declarations of the `centroided<-` and `smoothed<-` methods for OnDiskMSnExp objects. The complain is:

    arguments ('value') after '...' in the generic must appear in the method, in the same place at the end of the argument list

We've been notified by R-core that this breaks many CRAN packages that depend directly or indirectly on **MSnbase** when using the latest R devel.

This commit fixes the method delcarations so that they are compatible with R >= 4.4.

Best,
H.