### PR TITLE
refactor: move XML to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -96,7 +96,6 @@ Imports:
     ggplot2,
     scales,
     MASS,
-    XML,
     Rcpp
 Suggests:
     testthat,
@@ -119,6 +118,7 @@ Suggests:
     imputeLCMD,
     norm,
     gplots,
+    XML,
     shiny,
     magrittr,
     SummarizedExperiment
@@ -132,7 +132,7 @@ URL: https://lgatto.github.io/MSnbase
 biocViews: ImmunoOncology, Infrastructure, Proteomics, MassSpectrometry,
     QualityControl, DataImport
 Roxygen: list(markdown=TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.1
 Collate:
     'AllClassUnions.R'
     'AllGenerics.R'

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -25,7 +25,6 @@ importFrom(MsCoreUtils, closest, rbindFill,
            impute_matrix, normalize_matrix,
            robustSummary, medianPolish,
            formatRt)
-importFrom(XML, xmlParse, xpathSApply)
 importFrom(graphics, abline, axis, grid, legend, lines, points, text,
            barplot, layout, par, matplot, mtext)
 importFrom(stats, ave, median, medpolish, quantile, reorder, setNames,


### PR DESCRIPTION
This PR moves the XML package from Imports to Suggests and removes the import from the NAMESPACE. Package version was not bumped.