### PR TITLE
fix: disable nested parallel processing for chromatograms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MSnbase
 Title: Base Functions and Classes for Mass Spectrometry and Proteomics
-Version: 2.29.4
+Version: 2.29.5
 Description: MSnbase provides infrastructure for manipulation,
              processing and visualisation of mass spectrometry and
              proteomics data, ranging from raw to quantitative and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MSnbase 2.29
 
+## MSnbase 2.29.5
+
+- Disable nested parallel processing for `chromatogram()` method.
+
 ## MSnbase 2.29.4
 
 - Move XML to suggests.

--- a/R/functions-OnDiskMSnExp.R
+++ b/R/functions-OnDiskMSnExp.R
@@ -577,7 +577,7 @@ precursorValue_OnDiskMSnExp <- function(object, column) {
             match(fileNames(subs), fns),
             FUN = function(cur_sample, cur_file, rtm, mzm, aggFun) {
                 ## Load all spectra for that file. applies also any proc steps
-                sps <- spectra(cur_sample)
+                sps <- spectra(cur_sample, BPPARAM = SerialParam())
                 ## Related to issue #229: can we avoid getting all spectra and
                 ## just return the intensity values for each spectrum instead?
                 rts <- rtime(cur_sample)

--- a/R/methods-pSet.R
+++ b/R/methods-pSet.R
@@ -364,7 +364,7 @@ setMethod("length", "pSet", function(x) length(assayData(x)))
 
 setMethod("assayData", "pSet", function(object) object@assayData)
 
-setMethod("spectra", "MSnExp", function(object) {
+setMethod("spectra", "MSnExp", function(object, ...) {
     sl <- as.list(assayData(object))
     fnames <- featureNames(object)
     ## reordering the spectra in the spectra list to match

--- a/man/MSnSet-class.Rd
+++ b/man/MSnSet-class.Rd
@@ -10,12 +10,10 @@
 \alias{exprs,MSnSet-method}
 \alias{dim,MSnSet-method}
 \alias{fileNames,MSnSet-method}
-%%\alias{normalise,MSnSet-method}
 \alias{msInfo,MSnSet-method}
 \alias{processingData,MSnSet-method}
 \alias{qual,MSnSet-method}
 \alias{qual}
-%%\alias{ratios,MSnSet-method}
 \alias{show,MSnSet-method}
 \alias{purityCorrect,MSnSet-method}
 \alias{purityCorrect,MSnSet,matrix-method}
@@ -82,7 +80,6 @@
 \alias{detectorType,MSnSet-method}
 \alias{description,MSnSet-method}
 
-%% functions
 \alias{updateFvarLabels}
 \alias{updateSampleNames}
 \alias{updateFeatureNames}
@@ -214,9 +211,6 @@
   inherited methods.
 
   \describe{
-    %% \item{$name}{\code{signature(x = "pSet")}: Access \code{name} column
-    %%   in \code{featureData}. Note that this behaviour is different to
-    %%   the \code{eSet}, where \code{$} accesses the \code{phenoData}. }
     \item{acquisitionNum}{
       \code{acquisitionNum(signature(object = "MSnSet"))}: Returns the
       a numeric vector with acquisition number of each spectrum. The vector
@@ -235,26 +229,33 @@
       names.
     }
 
-
     \item{dim}{\code{signature(x = "MSnSet")}: Returns the dimensions of
       object's assay data, i.e the number of samples and the number of
       features. }
+
     \item{fileNames}{\code{signature(object = "MSnSet")}: Access file
       names in the \code{processingData} slot. }
+
     \item{msInfo}{\code{signature(object = "MSnSet")}: Prints the MIAPE-MS
       meta-data stored in the \code{experimentData} slot. }
+
     \item{processingData}{\code{signature(object = "MSnSet")}: Access the
       \code{processingData} slot. }
+
     \item{show}{\code{signature(object = "MSnSet")}: Displays object
       content as text. }
+
     \item{qual}{\code{signature(object = "MSnSet")}: Access the reporter
       ion peaks description. }
+
     \item{purityCorrect}{\code{signature(object = "MSnSet", impurities =
 	"matrix")}: performs reporter ions purity correction. See
       \code{\link{purityCorrect}} documentation for more details. }
+
     \item{normalise}{\code{signature(object = "MSnSet")}: Performs
       \code{MSnSet} normalisation. See \code{\link{normalise}} for more
       details. }
+
     \item{t}{\code{signature(x = "MSnSet")}: Returns a transposed
       \code{MSnSet} object where features are now aligned along columns
       and samples along rows and the \code{phenoData} and
@@ -281,23 +282,22 @@
       Coerce object from \code{MSnSet} to
       \code{SummarizedExperiment}. Only part of the metadata is
       retained. See \code{addMSnSetMetadata} and the example below for
-      details.  }
+      details.}
 
-    %% \item{ratios}{\code{signature(object = "MSnSet")}: ... }
-    \item{write.exprs}{signature(x = "MSnSet")}{Writes expression values
+    \item{write.exprs}{\code{signature(x = "MSnSet")}: Writes expression values
       to a tab-separated file (default is \code{tmp.txt}). The
       \code{fDataCols} parameter can be used to specify which
       \code{featureData} columns (as column names, column number or
       \code{logical}) to append on the right of the expression matrix.
       The following arguments are the same as \code{write.table}.}
 
-    \item{combine}{signature(x = "MSnSet", y = "MSnSet", ...)}{ Combines
+    \item{combine}{\code{signature(x = "MSnSet", y = "MSnSet", ...)}: Combines
       2 or more \code{MSnSet} instances according to their feature names.
       Note that the \code{qual} slot and the processing information are
       silently dropped. }
 
-    \item{topN}{signature(object = "MSnSet", groupBy, n = 3, fun, ..., verbose =
-      isMSnbaseVerbose())}{
+    \item{topN}{\code{signature(object = "MSnSet", groupBy, n = 3, fun,
+	..., verbose = isMSnbaseVerbose())}:
       Selects the \code{n} most intense features (typically peptides or
       spectra) out of all available for each set defined by
       \code{groupBy} (typically proteins) and creates a new instance of
@@ -316,8 +316,8 @@
       detailed in the \code{synapter} package vignette.
     }
 
-    \item{filterNA}{signature(object = "MSnSet", pNA = "numeric",
-      pattern = "character", droplevels = "logical")}{ This method
+    \item{filterNA}{\code{signature(object = "MSnSet", pNA = "numeric",
+      pattern = "character", droplevels = "logical")}: This method
       subsets \code{object} by removing features that have (strictly)
       more than \code{pNA} percent of NA values. Default \code{pNA} is
       0, which removes any feature that exhibits missing data.
@@ -335,38 +335,39 @@
       methods for missing data exploration.
     }
 
-    \item{filterZero}{signature(object = "MSnSet", pNA = "numeric",
-      pattern = "character", droplevels = "logical")}{ As
+    \item{filterZero}{\code{signature(object = "MSnSet", pNA = "numeric",
+      pattern = "character", droplevels = "logical")}: As
       \code{filterNA}, but for zeros.
     }
 
-    \item{filterMsLevel}{signature(object = "MSnSet", msLevel. =
-      "numeric", fcol = "character")}{ Keeps only spectra with level
+    \item{filterMsLevel}{\code{signature(object = "MSnSet", msLevel. =
+      "numeric", fcol = "character")} Keeps only spectra with level
       \code{msLevel.}, as defined by the \code{fcol} feature variable
-      (default is \code{"msLevel"}). }
+      (default is \code{"msLevel"}).
+    }
 
-
-    \item{log}{signature(object = "MSnSet", base = "numeric")}{ Log
+    \item{log}{\code{signature(object = "MSnSet", base = "numeric")} Log
       transforms \code{exprs(object)} using
       \code{base::log}. \code{base} (defaults is \code{e='exp(1)'}) must
       be a positive or complex number, the base with respect to which
       logarithms are computed.
     }
 
-    \item{droplevels}{signature(x = "MSnSet", ...)}{Drops the unused
+    \item{droplevels}{\code{signature(x = "MSnSet", ...)}Drops the unused
       factor levels in the \code{featureData} slot. See
       \code{\link{droplevels}} for details.
     }
 
-    \item{impute}{\code{signature(object = "MSnSet", ...)}}{
+    \item{impute}{\code{signature(object = "MSnSet", ...)}
       Performs data imputation on the \code{MSnSet} object.
       See \code{\link{impute}} for more details.
     }
 
-    \item{trimws}{signature(object = "MSnSet", ...)}{Trim leading and/or
+    \item{trimws}{\code{signature(object = "MSnSet", ...)}Trim leading and/or
       trailing white spaces in the feature data slot. Also available for
       \code{data.frame} objects. See \code{?base::\link[base]{trimws}}
-      for details.  }
+      for details.
+    }
 
   }
 
@@ -377,7 +378,7 @@
 
 \section{Plotting}{
   \describe{
-    \item{meanSdPlot}{\code{signature(object = "MSnSet")}}{ Plots row
+    \item{meanSdPlot}{\code{signature(object = "MSnSet")} Plots row
       standard deviations versus row means. See
       \code{\link{meanSdPlot}} (\code{vsn} package) for more details.
     }
@@ -385,7 +386,7 @@
     \item{image}{\code{signature(x = "MSnSet", facetBy = "character",
 	sOrderBy = "character", legend = "character", low = "character",
 	high = "character", fnames = "logical", nmax =
-	"numeric")}}{Produces an heatmap of expression values in the
+	"numeric")} Produces an heatmap of expression values in the
 	\code{x} object. Simple horizontal facetting is enabled by
 	passing a single character as \code{facetBy}. Arbitrary
 	facetting can be performed manually by saving the return value
@@ -410,17 +411,18 @@
       }
 
     \item{plotNA}{\code{signature(object = "MSnSet", pNA =
-	"numeric")}}{
+	"numeric")}
 	Plots missing data for an \code{MSnSet} instance. \code{pNA} is a
 	\code{numeric} of length 1 that specifies the percentage
 	of accepted missing data values per features. This value will be
 	highlighted with a point on the figure, illustrating the overall
 	percentage of NA values in the full data set and the number of
 	proteins retained. Default is 1/2. See also
-	\code{\link{plotNA}}.}
+	\code{\link{plotNA}}.
+      }
 
     \item{MAplot}{\code{signature(object = "MSnSet", log.it = "logical",
-	base = "numeric", ...)}}{
+	base = "numeric", ...)}
       Produces MA plots (Ratio as a function
       of average intensity) for the samples in \code{object}. If
       \code{ncol(object) == 2}, then one MA plot is produced using the
@@ -431,25 +433,30 @@
       \code{base}. Further \code{...} arguments will be passed to the
       respective functions.
     }
+
     \item{addIdentificationData}{\code{signature(object = "MSnSet", ...)}:
       Adds identification data to a \code{MSnSet} instance.
       See \code{\link{addIdentificationData}} documentation for
-      more details and examples. }
+      more details and examples.
+    }
 
     \item{removeNoId}{\code{signature(object = "MSnSet", fcol =
 	"pepseq", keep = NULL)}: Removes non-identified features. See
       \code{\link{removeNoId}} documentation for more details and
-      examples. }
+      examples.
+    }
 
     \item{removeMultipleAssignment}{\code{signature(object = "MSnSet",
 	fcol = "nprot")}: Removes protein groups (or feature belong to
 	protein groups) with more than one member. The latter is defined
 	by extracting a feature variable (default is
-	\code{"nprot"}). Also removes non-identified features/ }
+	\code{"nprot"}). Also removes non-identified features.
+      }
 
     \item{idSummary}{\code{signature(object = "MSnSet", ...)}: Prints a
       summary that lists the percentage of identified features per file
-      (called \code{coverage}). }
+      (called \code{coverage}).
+    }
 
   }
 }
@@ -457,28 +464,29 @@
 \section{Functions}{
   \describe{
 
-    \item{updateFvarLabels}{signature(object, label, sep)}{ This
+    \item{updateFvarLabels}{\code{signature(object, label, sep)} This
       function updates \code{object}'s featureData variable labels by
       appending \code{label}. By default, \code{label} is the variable
-      name and the separator \code{sep} is \code{.}.}
+      name and the separator \code{sep} is \code{.}.
+    }
 
-    \item{updateSampleNames}{signature(object, label, sep)}{ This
+    \item{updateSampleNames}{\code{signature(object, label, sep)} This
       function updates \code{object}'s sample names by appending
       \code{label}. By default, \code{label} is the variable name and
       the separator \code{sep} is \code{.}.}
 
-    \item{updateFeatureNames}{signature(object, label, sep)}{ This
+    \item{updateFeatureNames}{\code{signature(object, label, sep)} This
       function updates \code{object}'s feature names by appending
       \code{label}. By default, \code{label} is the variable name and
       the separator \code{sep} is \code{.}.}
 
-    \item{ms2df}{signature(x, fcols)}{Coerces the \code{MSnSet} instance
+    \item{ms2df}{\code{signature(x, fcols)} Coerces the \code{MSnSet} instance
       to a \code{data.frame}. The direction of the data is retained and
       the feature variable labels that match \code{fcol} are appended to
       the expression values. See also \code{as(x, "data.frame")} above.
       }
 
-    \item{addMSnSetMetadata}{signature(x, y)}{When coercing an
+    \item{addMSnSetMetadata}{\code{signature(x, y)} When coercing an
       \code{MSnSet} \code{y} to a \code{SummarizedExperiment} \code{x}
       with \code{x <- as(y, "SummarizedExperiment")}, most of \code{y}'s
       metadata is lost. Only the file names, the processing log and the
@@ -486,7 +494,8 @@
       along. The \code{addMSnSetMetadata} function can be used to add
       the complete \code{processingData}, \code{experimentData} and
       \code{protocolData} slots. The downside of this is that MSnbase is
-      now required to use the \code{SummarizedExperiment} object.  }
+      now required to use the \code{SummarizedExperiment} object.
+    }
 
   }
 }

--- a/man/ReporterIons-class.Rd
+++ b/man/ReporterIons-class.Rd
@@ -55,7 +55,7 @@
       6-plex set. Load with \code{data(TMT6)}. }
     \item{\code{TMT7}:}{\code{ReporterIon} object for the TMT
       6-plex set plus the isobaric tag. Load with \code{data(TMT6)}. }
-  }  
+  }
 }
 
 \section{Objects from the Class}{
@@ -103,7 +103,7 @@
     \item{\code{mz(object, ...)}}{ Returns the expected mz values of
       reporter ions. Additional arguments are currently ignored. }
     \item{\code{reporterColours(object)} or reporterColors(object)}{
-      Returns the colours used to highlight the reporter ions. } 
+      Returns the colours used to highlight the reporter ions. }
     \item{\code{reporterNames(object)}}{ Returns the name of the
       individual reporter ions. If not specified or is an incorrect
       number of names is provided at initialisation, the names are
@@ -129,16 +129,16 @@
   amine-reactive isobaric tagging reagents."
   \emph{Mol Cell Proteomics}, 2004 Dec;3(12):1154-69.
   Epub 2004 Sep 22. PubMed PMID: 15385600.
-  
-  Thompson A, Sch\"{a}fer J, Kuhn K, Kienle S, Schwarz J, Schmidt G,
+
+  Thompson A, Schäfer J, Kuhn K, Kienle S, Schwarz J, Schmidt G,
   Neumann T, Johnstone R, Mohammed AK, Hamon C.
   "Tandem mass tags: a novel quantification strategy for comparative
   analysis of complex protein mixtures by MS/MS."
   \emph{Anal Chem.} 2003 Apr 15;75(8):1895-904. \emph{Erratum} in:
   \emph{Anal Chem.} 2006 Jun 15;78(12):4235. Mohammed, A Karim A [added]
-  and  
+  and
   \emph{Anal Chem.} 2003 Sep 15;75(18):4942. Johnstone, R [added].
-  PubMed PMID: 12713048. 
+  PubMed PMID: 12713048.
 }
 
 \author{
@@ -161,7 +161,7 @@ ri[1:2]
 }
 
 \seealso{
-  \code{\link{TMT6}} or \code{\link{iTRAQ4}} for readily available examples. 
+  \code{\link{TMT6}} or \code{\link{iTRAQ4}} for readily available examples.
 }
 
 \keyword{classes}

--- a/man/TMT6.Rd
+++ b/man/TMT6.Rd
@@ -30,7 +30,7 @@
   These objects are used to plot the reporter ions of interest in an
   MSMS spectra (see \code{"\linkS4class{Spectrum2}"}) as well as for
   quantification (see \code{\link{quantify}}).
-  
+
 }
 
 \usage{
@@ -46,15 +46,15 @@ TMT11HCD
 }
 
 \references{
-  Thompson A, Sch\"{a}fer J, Kuhn K, Kienle S, Schwarz J, Schmidt G,
+  Thompson A, Schäfer J, Kuhn K, Kienle S, Schwarz J, Schmidt G,
   Neumann T, Johnstone R, Mohammed AK, Hamon C.
   "Tandem mass tags: a novel quantification strategy for comparative
   analysis of complex protein mixtures by MS/MS."
   \emph{Anal Chem.} 2003 Apr 15;75(8):1895-904. \emph{Erratum} in:
   \emph{Anal Chem.} 2006 Jun 15;78(12):4235. Mohammed, A Karim A [added]
-  and  
+  and
   \emph{Anal Chem.} 2003 Sep 15;75(18):4942. Johnstone, R [added].
-  PubMed PMID: 12713048. 
+  PubMed PMID: 12713048.
 }
 
 \examples{

--- a/man/listOf.Rd
+++ b/man/listOf.Rd
@@ -7,7 +7,7 @@
 listOf(x, class, valid = TRUE)
 }
 \arguments{
-\item{x}{A code{list}.}
+\item{x}{A \code{list}.}
 
 \item{class}{A \code{character} defining the expected class.}
 

--- a/man/pSet-class.Rd
+++ b/man/pSet-class.Rd
@@ -185,7 +185,7 @@
     \item{fileNames}{\code{signature(object = "pSet")}: Access file
       names in the \code{processingData} slot. }
     \item{fromFile}{\code{signature(object = "pSet")}: Access raw data
-      file indexes (to be found in the 'code{processingData}' slot) from
+      file indexes (to be found in the \code{processingData} slot) from
       which the individual object's spectra where read from. }
     \item{centroided}{\code{signature(object = "pSet")}: Indicates
       whether individual spectra are centroided ('TRUE') of uncentroided

--- a/man/plotNA-methods.Rd
+++ b/man/plotNA-methods.Rd
@@ -19,22 +19,22 @@
 
   The \code{plotNA} method produces plots that illustrate missing data.
   The completeness of the full dataset or a set of proteins (ordered by
-  increasing NA content along the x axis) is represented. 
+  increasing NA content along the x axis) is represented.
   The methods make use the \code{ggplot2} system. An object of class
-  'ggplot' is returned invisibly. 
+  'ggplot' is returned invisibly.
 }
 
 
 \section{Methods}{
   \describe{
-    \item{is.na}{\code{signature(x = "MSnSet")}}{      
+    \item{is.na}{\code{signature(x = "MSnSet")}
       Returns the a matrix of logicals of dimensions \code{dim(x)}
       specifiying if respective values are missing in the
       \code{MSnSet}'s expression matrix.
     }
-    \item{plotNA}{\code{signature(object = "MSnSet", pNA = "numeric")}}{
+    \item{plotNA}{\code{signature(object = "MSnSet", pNA = "numeric")}
       Plots missing data for an \code{MSnSet} instance. \code{pNA} is a
-      \code{numeric} of length 1 that specifies the percentage 
+      \code{numeric} of length 1 that specifies the percentage
       of accepted missing data values per features. This value will be
       highlighted with a point on the figure, illustrating the overall
       percentage of NA values in the full data set and the number of


### PR DESCRIPTION
This fix addresses a comment in issue
https://github.com/sneumann/xcms/issues/627#issuecomment-2080333123.

`chromatogram()` is extracting chromatograms in parallel for each sample/file. The internal function uses `spectra()` to load the data in each parallel process. The default value for `BPPARAM` of `spectra()` is however `BPPARAM = bpparam()`, thus, an eventual nested (and unnecessary) parallel processing setup is created. This PR forces the internal `spectra()` call to disable parallel processing.